### PR TITLE
Add GoJS layout gallery demos

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,395 +3,197 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GoJS 配网示例</title>
-    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <title>GoJS 布局示例画廊</title>
     <style>
-      html,
+      :root {
+        color-scheme: light;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
-        height: 100%;
         margin: 0;
         font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-        background-color: #f5f6fa;
+        color: #1f2933;
+        background: linear-gradient(160deg, #f8fafc 0%, #f1f5f9 40%, #e2e8f0 100%);
+        min-height: 100vh;
       }
 
-      .page {
-        max-width: 960px;
+      header {
+        background: rgba(15, 23, 42, 0.9);
+        color: #f8fafc;
+        padding: 32px 16px;
+        box-shadow: 0 8px 32px rgba(15, 23, 42, 0.18);
+      }
+
+      header .inner {
+        max-width: 1040px;
         margin: 0 auto;
-        padding: 24px 16px 48px;
-      }
-
-      h1 {
-        font-size: 24px;
-        font-weight: 600;
-        color: #1a2a5a;
-        margin: 0 0 16px;
-      }
-
-      p.description {
-        margin: 0 0 16px;
-        color: #4a4a4a;
-      }
-
-      #diagramDiv {
-        width: 100%;
-        height: 600px;
-        border: 1px solid #d0d5dd;
-        border-radius: 8px;
-        background-color: #ffffff;
-        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
-      }
-
-      .legend {
-        margin-top: 16px;
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        display: flex;
+        flex-direction: column;
         gap: 12px;
-        color: #4a4a4a;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(28px, 4vw, 40px);
+        letter-spacing: 0.03em;
+      }
+
+      header p {
+        margin: 0;
+        max-width: 680px;
+        line-height: 1.6;
+        color: rgba(248, 250, 252, 0.85);
+      }
+
+      main {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 40px 16px 64px;
+      }
+
+      .layout-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 24px;
+      }
+
+      .card {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 24px;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.82);
+        backdrop-filter: blur(8px);
+        text-decoration: none;
+        color: inherit;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+        transition: transform 0.25s ease, box-shadow 0.25s ease;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+      }
+
+      .card:hover,
+      .card:focus-visible {
+        transform: translateY(-6px);
+        box-shadow: 0 18px 38px rgba(15, 23, 42, 0.16);
+        outline: none;
+      }
+
+      .card h2 {
+        margin: 0;
+        font-size: 20px;
+        color: #0f172a;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #1d4ed8;
+        background-color: rgba(59, 130, 246, 0.12);
+        padding: 6px 10px;
+        border-radius: 999px;
+      }
+
+      .card p {
+        margin: 0;
+        line-height: 1.6;
+        color: #52606d;
+      }
+
+      .card span {
+        margin-top: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        color: #2563eb;
+      }
+
+      .card span::after {
+        content: "→";
+        font-size: 18px;
+        transition: transform 0.2s ease;
+      }
+
+      .card:hover span::after {
+        transform: translateX(4px);
+      }
+
+      footer {
+        text-align: center;
+        padding: 32px 16px 56px;
+        color: #475569;
         font-size: 14px;
       }
 
-      .legend-item {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .legend-swatch {
-        width: 28px;
-        height: 12px;
-        border-radius: 4px;
+      footer a {
+        color: inherit;
       }
     </style>
   </head>
   <body>
-    <div class="page">
-      <h1>配电网络拓扑示例</h1>
-      <p class="description">
-        该示例展示了使用 GoJS 构建的配电网拓扑。主干线路沿水平方向布置，并通过断路器、开关等节点将支路以树形方式向下延伸。
-      </p>
-      <div id="diagramDiv" role="presentation" aria-label="GoJS 配网示意图"></div>
-      <div class="legend">
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #005bac"></span>
-          <span>主干母线</span>
-        </div>
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #666"></span>
-          <span>竖向支路</span>
-        </div>
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #e8f5e9; border: 2px solid #1e7e34"></span>
-          <span>闭合开关</span>
-        </div>
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #fcebea; border: 2px dashed #e74c3c"></span>
-          <span>分闸开关</span>
-        </div>
+    <header>
+      <div class="inner">
+        <h1>GoJS 布局示例画廊</h1>
+        <p>
+          这里汇集了常见的 GoJS 图布局示例，每个示例都使用约 50 个节点，方便快速对比不同布局在复杂网络下的呈现效果。
+          点击任意卡片即可打开相应的互动案例页面。
+        </p>
       </div>
-    </div>
-
-    <script>
-      window.addEventListener("DOMContentLoaded", () => {
-        const $ = go.GraphObject.make;
-
-        const diagram = $(go.Diagram, "diagramDiv", {
-          layout: $(go.TreeLayout, {
-            angle: 90,
-            nodeSpacing: 40,
-            layerSpacing: 80,
-            alternateAngle: 90,
-            arrangement: go.TreeLayout.ArrangementHorizontal,
-            alignment: go.TreeLayout.AlignmentCenterChildren
-          }),
-          "animationManager.isEnabled": false,
-          "undoManager.isEnabled": true
-        });
-
-        const linkShapeBinding = new go.Binding("stroke", "linkColor", (color) => color || "#4a4a4a");
-
-        diagram.linkTemplate = $(
-          go.Link,
-          { routing: go.Link.Orthogonal, corner: 10, selectable: false },
-          $(go.Shape, { strokeWidth: 2 }, linkShapeBinding),
-          $(
-            go.Shape,
-            {
-              fromArrow: "",
-              toArrow: "",
-              strokeWidth: 2
-            },
-            linkShapeBinding
-          )
-        );
-
-        diagram.nodeTemplate = $(
-          go.Node,
-          "Auto",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Shape,
-            "RoundedRectangle",
-            {
-              fill: "#ddeaff",
-              stroke: "#5b7cfa",
-              strokeWidth: 1.5,
-              parameter1: 6
-            },
-            new go.Binding("fill", "loadType", (type) => {
-              if (type === "transformer") return "#fff3cd";
-              if (type === "user") return "#ddeaff";
-              return "#f1f5f9";
-            })
-          ),
-          $(
-            go.TextBlock,
-            {
-              margin: new go.Margin(8, 12),
-              font: "12px/1.4 'Segoe UI', sans-serif",
-              stroke: "#1f2933",
-              textAlign: "center",
-              wrap: go.TextBlock.WrapFit,
-              width: 140
-            },
-            new go.Binding("text")
-          )
-        );
-
-        const busTemplate = $(
-          go.Node,
-          "Spot",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Panel,
-            "Auto",
-            $(
-              go.Shape,
-              "Rectangle",
-              {
-                width: 240,
-                height: 18,
-                fill: "#005bac",
-                stroke: "#003d7a",
-                strokeWidth: 2,
-                spot1: go.Spot.LeftCenter,
-                spot2: go.Spot.RightCenter
-              }
-            ),
-            $(
-              go.TextBlock,
-              {
-                margin: 4,
-                stroke: "#ffffff",
-                font: "bold 13px 'Segoe UI', sans-serif"
-              },
-              new go.Binding("text")
-            )
-          )
-        );
-
-        const feederTemplate = $(
-          go.Node,
-          "Vertical",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Shape,
-            "Rectangle",
-            {
-              width: 10,
-              height: 70,
-              fill: "#666666",
-              stroke: null
-            }
-          ),
-          $(
-            go.TextBlock,
-            {
-              margin: new go.Margin(8, 0, 0, 0),
-              font: "12px 'Segoe UI', sans-serif",
-              stroke: "#374151"
-            },
-            new go.Binding("text")
-          )
-        );
-
-        const switchTemplate = $(
-          go.Node,
-          "Vertical",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Panel,
-            "Auto",
-            $(
-              go.Shape,
-              "RoundedRectangle",
-              {
-                width: 44,
-                height: 24,
-                strokeWidth: 2,
-                parameter1: 4
-              },
-              new go.Binding("fill", "switchState", (state) =>
-                state === "open" ? "#fcebea" : "#e8f5e9"
-              ),
-              new go.Binding("stroke", "switchState", (state) =>
-                state === "open" ? "#e74c3c" : "#1e7e34"
-              ),
-              new go.Binding("strokeDashArray", "switchState", (state) =>
-                state === "open" ? [4, 2] : null
-              )
-            ),
-            $(
-              go.TextBlock,
-              {
-                margin: 4,
-                font: "bold 11px 'Segoe UI', sans-serif",
-                stroke: "#1f2933"
-              },
-              new go.Binding("text", "shortLabel")
-            )
-          ),
-          $(
-            go.TextBlock,
-            {
-              margin: new go.Margin(6, 0, 0, 0),
-              font: "12px 'Segoe UI', sans-serif",
-              stroke: "#374151"
-            },
-            new go.Binding("text")
-          )
-        );
-
-        diagram.nodeTemplateMap.add("bus", busTemplate);
-        diagram.nodeTemplateMap.add("feeder", feederTemplate);
-        diagram.nodeTemplateMap.add("switch", switchTemplate);
-
-        const nodeDataArray = [
-          { key: 1, text: "10kV 主干母线", category: "bus" },
-          {
-            key: 2,
-            parent: 1,
-            text: "一段母线开关 QF1",
-            shortLabel: "QF1",
-            category: "switch",
-            switchState: "closed",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 3,
-            parent: 2,
-            text: "一号馈线",
-            category: "feeder",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 4,
-            parent: 3,
-            text: "配电变压器 T1",
-            category: "",
-            loadType: "transformer",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 5,
-            parent: 4,
-            text: "居民小区 A",
-            category: "",
-            loadType: "user",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 6,
-            parent: 1,
-            text: "分段开关 QS1",
-            shortLabel: "QS1",
-            category: "switch",
-            switchState: "open",
-            linkColor: "#e74c3c"
-          },
-          {
-            key: 7,
-            parent: 6,
-            text: "二号馈线",
-            category: "feeder",
-            linkColor: "#e74c3c"
-          },
-          {
-            key: 8,
-            parent: 7,
-            text: "环网柜 RMU",
-            category: "",
-            loadType: "transformer",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 9,
-            parent: 8,
-            text: "工业园区 B",
-            category: "",
-            loadType: "user",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 10,
-            parent: 1,
-            text: "线路联络开关 QS2",
-            shortLabel: "QS2",
-            category: "switch",
-            switchState: "closed",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 11,
-            parent: 10,
-            text: "三号馈线",
-            category: "feeder",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 12,
-            parent: 11,
-            text: "分支开关 QS3",
-            shortLabel: "QS3",
-            category: "switch",
-            switchState: "closed",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 13,
-            parent: 12,
-            text: "箱变 X1",
-            category: "",
-            loadType: "transformer",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 14,
-            parent: 13,
-            text: "商业楼宇 C",
-            category: "",
-            loadType: "user",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 15,
-            parent: 12,
-            text: "联络开关 QS4",
-            shortLabel: "QS4",
-            category: "switch",
-            switchState: "open",
-            linkColor: "#e74c3c"
-          },
-          {
-            key: 16,
-            parent: 15,
-            text: "备用支路",
-            category: "feeder",
-            linkColor: "#e74c3c"
-          }
-        ];
-
-        diagram.model = new go.TreeModel({ nodeDataArray });
-      });
-    </script>
+    </header>
+    <main>
+      <div class="layout-grid">
+        <a class="card" href="layouts/force-directed.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>ForceDirectedLayout</h2>
+          <p>
+            使用物理仿真算法让节点在弹簧和电荷作用下自动分布，适合探索无向网络关系，展示稠密连接的自然形态。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/circular.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>CircularLayout</h2>
+          <p>
+            将节点环形排列并添加跨圈连线，突出环状拓扑与社群划分，适合展示循环依赖或分组结构。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/layered-digraph.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>LayeredDigraphLayout</h2>
+          <p>
+            对有向图进行分层排布，强调信息从左至右的传递，演示多层流程或数据通道。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/tree.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>TreeLayout</h2>
+          <p>
+            多叉树结构自上而下展开，呈现 50 个节点的层级组织，适合可视化企业结构或配电网络。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/grid.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>GridLayout</h2>
+          <p>
+            节点按网格对齐，配合邻接连线展示矩阵型网络，便于观察规则拓扑的关联关系。
+          </p>
+          <span>查看示例</span>
+        </a>
+      </div>
+    </main>
+    <footer>基于 <a href="https://gojs.net" target="_blank" rel="noreferrer">GoJS</a> 最新版本构建</footer>
   </body>
 </html>

--- a/layouts/circular.html
+++ b/layouts/circular.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CircularLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #0f172a 0%, #1e1b4b 45%, #3f3cbb 100%);
+        color: #f8fafc;
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 28px 16px 16px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 34px);
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 520px;
+        color: rgba(226, 232, 240, 0.85);
+        line-height: 1.6;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 12px 16px 48px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #c4b5fd;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 620px;
+        border-radius: 18px;
+        border: 1px solid rgba(165, 180, 252, 0.25);
+        background: rgba(15, 23, 42, 0.55);
+        box-shadow: 0 32px 70px rgba(15, 23, 42, 0.4);
+      }
+
+      .legend {
+        margin-top: 18px;
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+        padding: 18px;
+        border-radius: 14px;
+        background: rgba(30, 41, 59, 0.8);
+        border: 1px solid rgba(165, 180, 252, 0.28);
+      }
+
+      .legend strong {
+        color: #ddd6fe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>CircularLayout 示例</h1>
+      <p>
+        将 50 个节点按照圆形环绕排布，并通过社群内部与跨社群的弦连接展示层次，便于观察环状网络的结构特征。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：120</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="CircularLayout 示例"></div>
+      <div class="legend">
+        <div><strong>颜色分区</strong>：每 10 个节点划分为同色社群，方便识别不同分组。</div>
+        <div><strong>连接模式</strong>：包含主环、社群内三角连接以及跨组跳线，模拟复杂环状关系。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const colors = ["#fbbf24", "#22d3ee", "#f472b6", "#34d399", "#a855f7"];
+        const nodeCount = 50;
+        const groupSize = 10;
+        const nodes = Array.from({ length: nodeCount }, (_, i) => ({
+          key: i,
+          text: `节点 ${i + 1}`,
+          group: Math.floor(i / groupSize),
+          fill: colors[Math.floor(i / groupSize)]
+        }));
+
+        const links = [];
+        for (let i = 0; i < nodeCount; i++) {
+          const next = (i + 1) % nodeCount;
+          links.push({ from: i, to: next });
+          const groupIndex = Math.floor(i / groupSize) * groupSize;
+          const intra1 = groupIndex + ((i + 3) % groupSize);
+          const intra2 = groupIndex + ((i + 6) % groupSize);
+          if (i !== intra1) links.push({ from: i, to: intra1 });
+          if (i !== intra2) links.push({ from: i, to: intra2 });
+          const cross = (i + groupSize) % nodeCount;
+          links.push({ from: i, to: cross });
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.CircularLayout, {
+            spacing: 20,
+            radius: 260,
+            nodeDiameterFormula: go.CircularLayout.Circular,
+            startAngle: 90
+          }),
+          allowHorizontalScroll: false,
+          allowVerticalScroll: false,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(go.Shape, "Circle", {
+            desiredSize: new go.Size(40, 40),
+            strokeWidth: 2,
+            stroke: "rgba(148, 163, 184, 0.4)",
+            fill: "#475569"
+          }, new go.Binding("fill", "fill")),
+          $(
+            go.TextBlock,
+            {
+              stroke: "#0f172a",
+              font: "bold 12px 'Segoe UI'",
+              margin: 4,
+              background: "rgba(248, 250, 252, 0.9)"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          { curve: go.Link.Bezier, selectable: false, opacity: 0.75 },
+          $(go.Shape, {
+            strokeWidth: 1.2,
+            stroke: "rgba(148, 163, 184, 0.75)"
+          })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/force-directed.html
+++ b/layouts/force-directed.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ForceDirectedLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background-color: #0f172a;
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 24px 16px;
+        text-align: center;
+        background: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), transparent 65%),
+          #0f172a;
+      }
+
+      header h1 {
+        margin: 0 0 8px;
+        font-size: clamp(26px, 4vw, 36px);
+        letter-spacing: 0.04em;
+      }
+
+      header p {
+        margin: 0;
+        color: rgba(226, 232, 240, 0.78);
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 16px 16px 48px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .back-link {
+        color: #93c5fd;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 18px;
+        background: radial-gradient(circle at center, rgba(59, 130, 246, 0.12), transparent 70%),
+          rgba(15, 23, 42, 0.88);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+      }
+
+      .legend {
+        margin-top: 18px;
+        padding: 16px 18px;
+        border-radius: 12px;
+        background: rgba(15, 23, 42, 0.78);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: grid;
+        gap: 8px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #bfdbfe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>ForceDirectedLayout 示例</h1>
+      <p>基于 50 个节点的复杂网络，通过力导向算法呈现自然舒展的结构。</p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：150</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="ForceDirectedLayout 示例"></div>
+      <div class="legend">
+        <div><strong>节点颜色</strong>：按社群编号着色，突出社群分布</div>
+        <div><strong>连接</strong>：包含环形主干与跨社群连接，模拟稠密关系网络</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const colors = ["#60a5fa", "#a855f7", "#34d399", "#f87171", "#facc15"];
+        const nodeCount = 50;
+        const nodes = Array.from({ length: nodeCount }, (_, i) => ({
+          key: i,
+          text: `节点 ${i + 1}`,
+          group: i % colors.length,
+          fill: colors[i % colors.length]
+        }));
+
+        const links = [];
+        for (let i = 0; i < nodeCount; i++) {
+          const next = (i + 1) % nodeCount;
+          const chord = (i + 5) % nodeCount;
+          const longChord = (i + 11) % nodeCount;
+          links.push({ from: i, to: next });
+          if (i !== chord) links.push({ from: i, to: chord });
+          if (i !== longChord) links.push({ from: i, to: longChord });
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.ForceDirectedLayout, {
+            defaultSpringLength: 120,
+            defaultElectricalCharge: 150
+          }),
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "Circle",
+            {
+              strokeWidth: 0,
+              fill: "#1e293b",
+              desiredSize: new go.Size(42, 42)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 4,
+              stroke: "#0f172a",
+              font: "bold 12px 'Segoe UI'",
+              background: "rgba(248, 250, 252, 0.9)",
+              maxSize: new go.Size(58, NaN)
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            curve: go.Link.Bezier,
+            adjusting: go.Link.Stretch,
+            opacity: 0.8,
+            selectable: false
+          },
+          $(go.Shape, {
+            strokeWidth: 1.5,
+            stroke: "rgba(148, 163, 184, 0.65)"
+          })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/grid.html
+++ b/layouts/grid.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GridLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(120deg, #0f172a 0%, #082f49 100%);
+        color: #e0f2fe;
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 30px 16px 18px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 36px);
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 620px;
+        color: rgba(191, 219, 254, 0.9);
+        line-height: 1.6;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 16px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 18px;
+        border: 1px solid rgba(125, 211, 252, 0.4);
+        background: rgba(8, 47, 73, 0.75);
+        box-shadow: 0 32px 80px rgba(8, 47, 73, 0.5);
+      }
+
+      .legend {
+        margin-top: 18px;
+        display: grid;
+        gap: 10px;
+        padding: 18px;
+        border-radius: 14px;
+        background: rgba(8, 47, 73, 0.7);
+        border: 1px solid rgba(14, 165, 233, 0.4);
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #7dd3fc;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>GridLayout 示例</h1>
+      <p>
+        将 49 个节点按照 7×7 的网格对齐，并通过行列邻接连线展示矩阵拓扑，适合查看规则结构中的连通性。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：49 · 连接数：84</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="GridLayout 示例"></div>
+      <div class="legend">
+        <div><strong>颜色梯度</strong>：按行使用由浅至深的蓝色系，便于识别行信息。</div>
+        <div><strong>连线设计</strong>：链接相邻行列节点，突出网格拓扑结构。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const rows = 7;
+        const cols = 7;
+        const palette = ["#bae6fd", "#7dd3fc", "#38bdf8", "#0ea5e9", "#0284c7", "#0369a1", "#0f172a"];
+
+        const nodes = [];
+        for (let r = 0; r < rows; r++) {
+          for (let c = 0; c < cols; c++) {
+            const key = r * cols + c;
+            nodes.push({
+              key,
+              text: `(${r + 1}, ${c + 1})`,
+              row: r,
+              col: c,
+              fill: palette[r]
+            });
+          }
+        }
+
+        const links = [];
+        for (let r = 0; r < rows; r++) {
+          for (let c = 0; c < cols; c++) {
+            const from = r * cols + c;
+            if (c < cols - 1) {
+              links.push({ from, to: from + 1 });
+            }
+            if (r < rows - 1) {
+              links.push({ from, to: from + cols });
+            }
+          }
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.GridLayout, {
+            wrappingColumn: cols,
+            spacing: new go.Size(50, 40),
+            alignment: go.GridLayout.Position
+          }),
+          allowHorizontalScroll: false,
+          allowVerticalScroll: false,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              strokeWidth: 0,
+              fill: "#0ea5e9",
+              desiredSize: new go.Size(72, 44)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              font: "bold 13px 'Segoe UI'",
+              stroke: "#082f49"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 4,
+            selectable: false,
+            opacity: 0.85
+          },
+          $(go.Shape, { strokeWidth: 1.2, stroke: "rgba(125, 211, 252, 0.7)" })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/layered-digraph.html
+++ b/layouts/layered-digraph.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LayeredDigraphLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+        color: #0f172a;
+      }
+
+      header {
+        padding: 32px 16px 20px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 36px);
+        color: #1f2937;
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 640px;
+        line-height: 1.6;
+        color: #4b5563;
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 16px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #2563eb;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: #ffffff;
+        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
+      }
+
+      .legend {
+        margin-top: 20px;
+        display: grid;
+        gap: 10px;
+        padding: 18px 20px;
+        border-radius: 14px;
+        background: rgba(226, 232, 240, 0.6);
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #1f2937;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>LayeredDigraphLayout 示例</h1>
+      <p>
+        以 5 层流程结构展示 50 个节点，强调方向性关系以及跨层交叉链接，模拟数据管道或业务流程图。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：120</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="LayeredDigraphLayout 示例"></div>
+      <div class="legend">
+        <div><strong>节点配色</strong>：根据层级使用渐变色，方便识别流程进度。</div>
+        <div><strong>连线设计</strong>：除顺层连线外加入跨层跳线，用以展示复杂依赖。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const layerCount = 5;
+        const nodesPerLayer = 10;
+        const colors = ["#bfdbfe", "#93c5fd", "#60a5fa", "#3b82f6", "#2563eb"];
+
+        const nodes = [];
+        for (let layer = 0; layer < layerCount; layer++) {
+          for (let index = 0; index < nodesPerLayer; index++) {
+            const key = layer * nodesPerLayer + index;
+            nodes.push({
+              key,
+              text: `L${layer + 1}-${index + 1}`,
+              layer,
+              fill: colors[layer]
+            });
+          }
+        }
+
+        const links = [];
+        for (let layer = 0; layer < layerCount; layer++) {
+          for (let index = 0; index < nodesPerLayer; index++) {
+            const from = layer * nodesPerLayer + index;
+            if (layer < layerCount - 1) {
+              const nextLayerStart = (layer + 1) * nodesPerLayer;
+              const target1 = nextLayerStart + (index % nodesPerLayer);
+              const target2 = nextLayerStart + ((index + 3) % nodesPerLayer);
+              links.push({ from, to: target1 });
+              if (target2 !== target1) links.push({ from, to: target2 });
+            }
+            if (layer < layerCount - 2 && index % 2 === 0) {
+              const skipLayerStart = (layer + 2) * nodesPerLayer;
+              const target = skipLayerStart + ((index + layer) % nodesPerLayer);
+              links.push({ from, to: target });
+            }
+          }
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.LayeredDigraphLayout, {
+            direction: 0,
+            layerSpacing: 90,
+            columnSpacing: 16,
+            setsPortSpots: false
+          }),
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              strokeWidth: 0,
+              fill: "#e2e8f0",
+              desiredSize: new go.Size(120, 42)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              font: "bold 13px 'Segoe UI'",
+              stroke: "#1f2937"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 6,
+            fromEndSegmentLength: 10,
+            toEndSegmentLength: 10,
+            selectable: false
+          },
+          $(go.Shape, { strokeWidth: 1.5, stroke: "#1d4ed8" })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/tree.html
+++ b/layouts/tree.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TreeLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #ecfeff 0%, #fef3c7 100%);
+        color: #0f172a;
+      }
+
+      header {
+        padding: 32px 16px 20px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 36px);
+        color: #1f2937;
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 600px;
+        line-height: 1.6;
+        color: #4b5563;
+      }
+
+      main {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 16px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #d97706;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 16px;
+        border: 1px solid rgba(234, 179, 8, 0.4);
+        background: rgba(255, 255, 255, 0.85);
+        box-shadow: 0 24px 60px rgba(217, 119, 6, 0.18);
+      }
+
+      .legend {
+        margin-top: 18px;
+        display: grid;
+        gap: 10px;
+        padding: 16px 18px;
+        border-radius: 12px;
+        background: rgba(253, 230, 138, 0.4);
+        border: 1px solid rgba(217, 119, 6, 0.32);
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #b45309;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>TreeLayout 示例</h1>
+      <p>
+        自上而下展开的多层树形结构，包含 50 个节点，能够清晰展示配电网络或组织架构的层级关系。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：49</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="TreeLayout 示例"></div>
+      <div class="legend">
+        <div><strong>节点配色</strong>：根据层级深度渐变，帮助区分不同层级。</div>
+        <div><strong>布局参数</strong>：使用 angle=90 的 TreeLayout，自上而下展开，每层保持均匀间距。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const colors = ["#fde68a", "#fbbf24", "#f59e0b", "#d97706", "#b45309"];
+        const nodeCount = 50;
+        const nodes = [{ key: 0, text: "中心节点", level: 0, fill: colors[0] }];
+
+        for (let i = 1; i < nodeCount; i++) {
+          const parentIndex = Math.floor((i - 1) / 3);
+          const parent = nodes[parentIndex];
+          const level = Math.min(parent.level + 1, colors.length - 1);
+          nodes.push({
+            key: i,
+            parent: parent.key,
+            text: `节点 ${i + 1}`,
+            level,
+            fill: colors[level]
+          });
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.TreeLayout, {
+            angle: 90,
+            nodeSpacing: 24,
+            layerSpacing: 80
+          }),
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              fill: "#fde68a",
+              stroke: "rgba(180, 83, 9, 0.2)",
+              strokeWidth: 1,
+              desiredSize: new go.Size(110, 44)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              font: "bold 13px 'Segoe UI'",
+              stroke: "#78350f"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 6,
+            selectable: false
+          },
+          $(go.Shape, { strokeWidth: 1.5, stroke: "rgba(180, 83, 9, 0.6)" })
+        );
+
+        diagram.model = new go.TreeModel({ nodeDataArray: nodes });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- redesign the landing page into a GoJS layout gallery with navigation cards for five demos
- add dedicated demos for ForceDirected, Circular, LayeredDigraph, Tree, and Grid layouts, each visualizing about 50 interconnected nodes

## Testing
- not run (static HTML changes only)


------
https://chatgpt.com/codex/tasks/task_b_68cdfd82c5c88327b1ffb621fd774b27