### PR TITLE
Fix layout initialization for DoubleTree and Packed demos

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,395 +3,253 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GoJS 配网示例</title>
-    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <title>GoJS 布局示例画廊</title>
     <style>
-      html,
+      :root {
+        color-scheme: light;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
-        height: 100%;
         margin: 0;
         font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-        background-color: #f5f6fa;
+        color: #1f2933;
+        background: linear-gradient(160deg, #f8fafc 0%, #f1f5f9 40%, #e2e8f0 100%);
+        min-height: 100vh;
       }
 
-      .page {
-        max-width: 960px;
+      header {
+        background: rgba(15, 23, 42, 0.9);
+        color: #f8fafc;
+        padding: 32px 16px;
+        box-shadow: 0 8px 32px rgba(15, 23, 42, 0.18);
+      }
+
+      header .inner {
+        max-width: 1040px;
         margin: 0 auto;
-        padding: 24px 16px 48px;
-      }
-
-      h1 {
-        font-size: 24px;
-        font-weight: 600;
-        color: #1a2a5a;
-        margin: 0 0 16px;
-      }
-
-      p.description {
-        margin: 0 0 16px;
-        color: #4a4a4a;
-      }
-
-      #diagramDiv {
-        width: 100%;
-        height: 600px;
-        border: 1px solid #d0d5dd;
-        border-radius: 8px;
-        background-color: #ffffff;
-        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
-      }
-
-      .legend {
-        margin-top: 16px;
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        display: flex;
+        flex-direction: column;
         gap: 12px;
-        color: #4a4a4a;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(28px, 4vw, 40px);
+        letter-spacing: 0.03em;
+      }
+
+      header p {
+        margin: 0;
+        max-width: 680px;
+        line-height: 1.6;
+        color: rgba(248, 250, 252, 0.85);
+      }
+
+      main {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 40px 16px 64px;
+      }
+
+      .layout-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 24px;
+      }
+
+      .card {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        padding: 24px;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.82);
+        backdrop-filter: blur(8px);
+        text-decoration: none;
+        color: inherit;
+        box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+        transition: transform 0.25s ease, box-shadow 0.25s ease;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+      }
+
+      .card:hover,
+      .card:focus-visible {
+        transform: translateY(-6px);
+        box-shadow: 0 18px 38px rgba(15, 23, 42, 0.16);
+        outline: none;
+      }
+
+      .card h2 {
+        margin: 0;
+        font-size: 20px;
+        color: #0f172a;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #1d4ed8;
+        background-color: rgba(59, 130, 246, 0.12);
+        padding: 6px 10px;
+        border-radius: 999px;
+      }
+
+      .card p {
+        margin: 0;
+        line-height: 1.6;
+        color: #52606d;
+      }
+
+      .card span {
+        margin-top: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        color: #2563eb;
+      }
+
+      .card span::after {
+        content: "→";
+        font-size: 18px;
+        transition: transform 0.2s ease;
+      }
+
+      .card:hover span::after {
+        transform: translateX(4px);
+      }
+
+      footer {
+        text-align: center;
+        padding: 32px 16px 56px;
+        color: #475569;
         font-size: 14px;
       }
 
-      .legend-item {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .legend-swatch {
-        width: 28px;
-        height: 12px;
-        border-radius: 4px;
+      footer a {
+        color: inherit;
       }
     </style>
   </head>
   <body>
-    <div class="page">
-      <h1>配电网络拓扑示例</h1>
-      <p class="description">
-        该示例展示了使用 GoJS 构建的配电网拓扑。主干线路沿水平方向布置，并通过断路器、开关等节点将支路以树形方式向下延伸。
-      </p>
-      <div id="diagramDiv" role="presentation" aria-label="GoJS 配网示意图"></div>
-      <div class="legend">
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #005bac"></span>
-          <span>主干母线</span>
-        </div>
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #666"></span>
-          <span>竖向支路</span>
-        </div>
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #e8f5e9; border: 2px solid #1e7e34"></span>
-          <span>闭合开关</span>
-        </div>
-        <div class="legend-item">
-          <span class="legend-swatch" style="background-color: #fcebea; border: 2px dashed #e74c3c"></span>
-          <span>分闸开关</span>
-        </div>
+    <header>
+      <div class="inner">
+        <h1>GoJS 布局示例画廊</h1>
+        <p>
+          这里汇集了 GoJS 内建布局与常用扩展布局，共 12 个案例，每个示例都使用约 50 个节点，方便快速对比不同算法在复杂网络下的呈现效果。
+          点击任意卡片即可打开互动页面，查看节点连线细节。
+        </p>
       </div>
-    </div>
-
-    <script>
-      window.addEventListener("DOMContentLoaded", () => {
-        const $ = go.GraphObject.make;
-
-        const diagram = $(go.Diagram, "diagramDiv", {
-          layout: $(go.TreeLayout, {
-            angle: 90,
-            nodeSpacing: 40,
-            layerSpacing: 80,
-            alternateAngle: 90,
-            arrangement: go.TreeLayout.ArrangementHorizontal,
-            alignment: go.TreeLayout.AlignmentCenterChildren
-          }),
-          "animationManager.isEnabled": false,
-          "undoManager.isEnabled": true
-        });
-
-        const linkShapeBinding = new go.Binding("stroke", "linkColor", (color) => color || "#4a4a4a");
-
-        diagram.linkTemplate = $(
-          go.Link,
-          { routing: go.Link.Orthogonal, corner: 10, selectable: false },
-          $(go.Shape, { strokeWidth: 2 }, linkShapeBinding),
-          $(
-            go.Shape,
-            {
-              fromArrow: "",
-              toArrow: "",
-              strokeWidth: 2
-            },
-            linkShapeBinding
-          )
-        );
-
-        diagram.nodeTemplate = $(
-          go.Node,
-          "Auto",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Shape,
-            "RoundedRectangle",
-            {
-              fill: "#ddeaff",
-              stroke: "#5b7cfa",
-              strokeWidth: 1.5,
-              parameter1: 6
-            },
-            new go.Binding("fill", "loadType", (type) => {
-              if (type === "transformer") return "#fff3cd";
-              if (type === "user") return "#ddeaff";
-              return "#f1f5f9";
-            })
-          ),
-          $(
-            go.TextBlock,
-            {
-              margin: new go.Margin(8, 12),
-              font: "12px/1.4 'Segoe UI', sans-serif",
-              stroke: "#1f2933",
-              textAlign: "center",
-              wrap: go.TextBlock.WrapFit,
-              width: 140
-            },
-            new go.Binding("text")
-          )
-        );
-
-        const busTemplate = $(
-          go.Node,
-          "Spot",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Panel,
-            "Auto",
-            $(
-              go.Shape,
-              "Rectangle",
-              {
-                width: 240,
-                height: 18,
-                fill: "#005bac",
-                stroke: "#003d7a",
-                strokeWidth: 2,
-                spot1: go.Spot.LeftCenter,
-                spot2: go.Spot.RightCenter
-              }
-            ),
-            $(
-              go.TextBlock,
-              {
-                margin: 4,
-                stroke: "#ffffff",
-                font: "bold 13px 'Segoe UI', sans-serif"
-              },
-              new go.Binding("text")
-            )
-          )
-        );
-
-        const feederTemplate = $(
-          go.Node,
-          "Vertical",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Shape,
-            "Rectangle",
-            {
-              width: 10,
-              height: 70,
-              fill: "#666666",
-              stroke: null
-            }
-          ),
-          $(
-            go.TextBlock,
-            {
-              margin: new go.Margin(8, 0, 0, 0),
-              font: "12px 'Segoe UI', sans-serif",
-              stroke: "#374151"
-            },
-            new go.Binding("text")
-          )
-        );
-
-        const switchTemplate = $(
-          go.Node,
-          "Vertical",
-          { locationSpot: go.Spot.Center },
-          $(
-            go.Panel,
-            "Auto",
-            $(
-              go.Shape,
-              "RoundedRectangle",
-              {
-                width: 44,
-                height: 24,
-                strokeWidth: 2,
-                parameter1: 4
-              },
-              new go.Binding("fill", "switchState", (state) =>
-                state === "open" ? "#fcebea" : "#e8f5e9"
-              ),
-              new go.Binding("stroke", "switchState", (state) =>
-                state === "open" ? "#e74c3c" : "#1e7e34"
-              ),
-              new go.Binding("strokeDashArray", "switchState", (state) =>
-                state === "open" ? [4, 2] : null
-              )
-            ),
-            $(
-              go.TextBlock,
-              {
-                margin: 4,
-                font: "bold 11px 'Segoe UI', sans-serif",
-                stroke: "#1f2933"
-              },
-              new go.Binding("text", "shortLabel")
-            )
-          ),
-          $(
-            go.TextBlock,
-            {
-              margin: new go.Margin(6, 0, 0, 0),
-              font: "12px 'Segoe UI', sans-serif",
-              stroke: "#374151"
-            },
-            new go.Binding("text")
-          )
-        );
-
-        diagram.nodeTemplateMap.add("bus", busTemplate);
-        diagram.nodeTemplateMap.add("feeder", feederTemplate);
-        diagram.nodeTemplateMap.add("switch", switchTemplate);
-
-        const nodeDataArray = [
-          { key: 1, text: "10kV 主干母线", category: "bus" },
-          {
-            key: 2,
-            parent: 1,
-            text: "一段母线开关 QF1",
-            shortLabel: "QF1",
-            category: "switch",
-            switchState: "closed",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 3,
-            parent: 2,
-            text: "一号馈线",
-            category: "feeder",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 4,
-            parent: 3,
-            text: "配电变压器 T1",
-            category: "",
-            loadType: "transformer",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 5,
-            parent: 4,
-            text: "居民小区 A",
-            category: "",
-            loadType: "user",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 6,
-            parent: 1,
-            text: "分段开关 QS1",
-            shortLabel: "QS1",
-            category: "switch",
-            switchState: "open",
-            linkColor: "#e74c3c"
-          },
-          {
-            key: 7,
-            parent: 6,
-            text: "二号馈线",
-            category: "feeder",
-            linkColor: "#e74c3c"
-          },
-          {
-            key: 8,
-            parent: 7,
-            text: "环网柜 RMU",
-            category: "",
-            loadType: "transformer",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 9,
-            parent: 8,
-            text: "工业园区 B",
-            category: "",
-            loadType: "user",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 10,
-            parent: 1,
-            text: "线路联络开关 QS2",
-            shortLabel: "QS2",
-            category: "switch",
-            switchState: "closed",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 11,
-            parent: 10,
-            text: "三号馈线",
-            category: "feeder",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 12,
-            parent: 11,
-            text: "分支开关 QS3",
-            shortLabel: "QS3",
-            category: "switch",
-            switchState: "closed",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 13,
-            parent: 12,
-            text: "箱变 X1",
-            category: "",
-            loadType: "transformer",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 14,
-            parent: 13,
-            text: "商业楼宇 C",
-            category: "",
-            loadType: "user",
-            linkColor: "#4a4a4a"
-          },
-          {
-            key: 15,
-            parent: 12,
-            text: "联络开关 QS4",
-            shortLabel: "QS4",
-            category: "switch",
-            switchState: "open",
-            linkColor: "#e74c3c"
-          },
-          {
-            key: 16,
-            parent: 15,
-            text: "备用支路",
-            category: "feeder",
-            linkColor: "#e74c3c"
-          }
-        ];
-
-        diagram.model = new go.TreeModel({ nodeDataArray });
-      });
-    </script>
+    </header>
+    <main>
+      <div class="layout-grid">
+        <a class="card" href="layouts/force-directed.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>ForceDirectedLayout</h2>
+          <p>
+            使用物理仿真算法让节点在弹簧和电荷作用下自动分布，适合探索无向网络关系，展示稠密连接的自然形态。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/circular.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>CircularLayout</h2>
+          <p>
+            将节点环形排列并添加跨圈连线，突出环状拓扑与社群划分，适合展示循环依赖或分组结构。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/layered-digraph.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>LayeredDigraphLayout</h2>
+          <p>
+            对有向图进行分层排布，强调信息从左至右的传递，演示多层流程或数据通道。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/tree.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>TreeLayout</h2>
+          <p>
+            多叉树结构自上而下展开，呈现 50 个节点的层级组织，适合可视化企业结构或配电网络。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/grid.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>GridLayout</h2>
+          <p>
+            节点按网格对齐，配合邻接连线展示矩阵型网络，便于观察规则拓扑的关联关系。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/radial.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>RadialLayout</h2>
+          <p>
+            围绕核心节点绘制同心层，快速展示知识地图或组织辐射网络的多级扩散关系。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/spiral.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>SpiralLayout</h2>
+          <p>
+            将节点沿螺旋链路排列，并加入跨臂连线，强调任务推进节奏与阶段间的交互引用。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/double-tree.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>DoubleTreeLayout</h2>
+          <p>
+            通过中心节点向左右扩散生成对称心智图，一侧聚焦策略，一侧关注落地执行细节。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/serpentine.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>SerpentineLayout</h2>
+          <p>
+            以蛇形路径串联 50 个阶段节点，自动换行展示长链路的推进节奏，并以虚线标注跨阶段依赖。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/parallel.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>ParallelLayout</h2>
+          <p>
+            以单一分流节点派生四条并行流程，观察 50 个任务的左右支路及其关键同步点如何在合流处收敛。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/packed.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>PackedLayout</h2>
+          <p>
+            将 50 个节点紧凑装填进椭圆边界，节点面积代表活跃度，辅以跨集群连线展示协同关系。
+          </p>
+          <span>查看示例</span>
+        </a>
+        <a class="card" href="layouts/fishbone.html">
+          <span class="badge">GoJS 布局</span>
+          <h2>FishboneLayout</h2>
+          <p>
+            采用鱼骨图形式梳理 50 个根因要素，从主干问题向左右分支发散，突出原因归类。
+          </p>
+          <span>查看示例</span>
+        </a>
+      </div>
+    </main>
+    <footer>基于 <a href="https://gojs.net" target="_blank" rel="noreferrer">GoJS</a> 最新版本构建</footer>
   </body>
 </html>

--- a/layouts/circular.html
+++ b/layouts/circular.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CircularLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #0f172a 0%, #1e1b4b 45%, #3f3cbb 100%);
+        color: #f8fafc;
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 28px 16px 16px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 34px);
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 520px;
+        color: rgba(226, 232, 240, 0.85);
+        line-height: 1.6;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 12px 16px 48px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #c4b5fd;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 620px;
+        border-radius: 18px;
+        border: 1px solid rgba(165, 180, 252, 0.25);
+        background: rgba(15, 23, 42, 0.55);
+        box-shadow: 0 32px 70px rgba(15, 23, 42, 0.4);
+      }
+
+      .legend {
+        margin-top: 18px;
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+        padding: 18px;
+        border-radius: 14px;
+        background: rgba(30, 41, 59, 0.8);
+        border: 1px solid rgba(165, 180, 252, 0.28);
+      }
+
+      .legend strong {
+        color: #ddd6fe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>CircularLayout 示例</h1>
+      <p>
+        将 50 个节点按照圆形环绕排布，并通过社群内部与跨社群的弦连接展示层次，便于观察环状网络的结构特征。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：120</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="CircularLayout 示例"></div>
+      <div class="legend">
+        <div><strong>颜色分区</strong>：每 10 个节点划分为同色社群，方便识别不同分组。</div>
+        <div><strong>连接模式</strong>：包含主环、社群内三角连接以及跨组跳线，模拟复杂环状关系。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const colors = ["#fbbf24", "#22d3ee", "#f472b6", "#34d399", "#a855f7"];
+        const nodeCount = 50;
+        const groupSize = 10;
+        const nodes = Array.from({ length: nodeCount }, (_, i) => ({
+          key: i,
+          text: `节点 ${i + 1}`,
+          group: Math.floor(i / groupSize),
+          fill: colors[Math.floor(i / groupSize)]
+        }));
+
+        const links = [];
+        for (let i = 0; i < nodeCount; i++) {
+          const next = (i + 1) % nodeCount;
+          links.push({ from: i, to: next });
+          const groupIndex = Math.floor(i / groupSize) * groupSize;
+          const intra1 = groupIndex + ((i + 3) % groupSize);
+          const intra2 = groupIndex + ((i + 6) % groupSize);
+          if (i !== intra1) links.push({ from: i, to: intra1 });
+          if (i !== intra2) links.push({ from: i, to: intra2 });
+          const cross = (i + groupSize) % nodeCount;
+          links.push({ from: i, to: cross });
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.CircularLayout, {
+            spacing: 20,
+            radius: 260,
+            nodeDiameterFormula: go.CircularLayout.Circular,
+            startAngle: 90
+          }),
+          allowHorizontalScroll: false,
+          allowVerticalScroll: false,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(go.Shape, "Circle", {
+            desiredSize: new go.Size(40, 40),
+            strokeWidth: 2,
+            stroke: "rgba(148, 163, 184, 0.4)",
+            fill: "#475569"
+          }, new go.Binding("fill", "fill")),
+          $(
+            go.TextBlock,
+            {
+              stroke: "#0f172a",
+              font: "bold 12px 'Segoe UI'",
+              margin: 4,
+              background: "rgba(248, 250, 252, 0.9)"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          { curve: go.Link.Bezier, selectable: false, opacity: 0.75 },
+          $(go.Shape, {
+            strokeWidth: 1.2,
+            stroke: "rgba(148, 163, 184, 0.75)"
+          })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/double-tree.html
+++ b/layouts/double-tree.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DoubleTreeLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <script src="https://gojs.net/latest/extensions/DoubleTreeLayout.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(140deg, #f1f5f9 0%, #e2e8f0 40%, #cbd5f5 100%);
+        color: #0f172a;
+      }
+
+      header {
+        padding: 34px 16px 20px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 12px;
+        font-size: clamp(26px, 4vw, 36px);
+        letter-spacing: 0.05em;
+        color: #1f2937;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 720px;
+        line-height: 1.6;
+        color: #334155;
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 20px 16px 60px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 14px;
+      }
+
+      .back-link {
+        color: #2563eb;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 20px;
+        background: #ffffff;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        box-shadow: 0 22px 60px rgba(15, 23, 42, 0.2);
+      }
+
+      .legend {
+        margin-top: 22px;
+        padding: 18px 20px;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.86);
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #1d4ed8;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>DoubleTreeLayout 示例</h1>
+      <p>
+        以中心主题向左右扩散为骨架，构建 50 节点的心智图谱，一侧聚焦战略规划，另一侧落地执行细节。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span id="stats">节点数：0 · 连接数：0</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="DoubleTreeLayout 示例"></div>
+      <div class="legend">
+        <div><strong>左右对称</strong>：根节点子树依据 dir 属性向两侧展开，实现战略与执行两大板块的对照分析。</div>
+        <div><strong>层级划分</strong>：每个主题节点衍生若干关键举措与具体任务，快速形成结构化思维导图。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const branchPalette = {
+          left: ["#38bdf8", "#60a5fa", "#a855f7"],
+          right: ["#f97316", "#facc15", "#22c55e"]
+        };
+
+        const leftPlan = [
+          { label: "市场洞察", topics: [2, 2, 2] },
+          { label: "产品路线", topics: [3, 2] },
+          { label: "渠道策略", topics: [2, 1] }
+        ];
+        const rightPlan = [
+          { label: "实施计划", topics: [3, 2, 2] },
+          { label: "团队协同", topics: [2, 2] },
+          { label: "度量反馈", topics: [2, 2] }
+        ];
+
+        const nodeDataArray = [{ key: "核心", text: "增长蓝图", color: "#2563eb" }];
+
+        const buildSide = (plan, dir) => {
+          plan.forEach((branch, branchIndex) => {
+            const branchKey = `${dir}-${branchIndex}`;
+            const branchColor = branchPalette[dir][branchIndex % branchPalette[dir].length];
+            nodeDataArray.push({ key: branchKey, parent: "核心", dir, text: branch.label, color: branchColor });
+
+            branch.topics.forEach((taskCount, topicIndex) => {
+              const topicKey = `${branchKey}-T${topicIndex}`;
+              nodeDataArray.push({
+                key: topicKey,
+                parent: branchKey,
+                text: `${branch.label}·模块 ${topicIndex + 1}`,
+                color: branchColor
+              });
+
+              for (let i = 0; i < taskCount; i++) {
+                const detailKey = `${topicKey}-D${i}`;
+                nodeDataArray.push({
+                  key: detailKey,
+                  parent: topicKey,
+                  text: `${branch.label} 行动 ${topicIndex + 1}-${i + 1}`,
+                  color: branchColor
+                });
+              }
+            });
+          });
+        };
+
+        buildSide(leftPlan, "left");
+        buildSide(rightPlan, "right");
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: new go.DoubleTreeLayout({
+            directionFunction: (node) => node.data && node.data.dir !== "left",
+            bottomRightOptions: { nodeSpacing: 18, layerSpacing: 36 },
+            topLeftOptions: { nodeSpacing: 18, layerSpacing: 36 }
+          }),
+          initialContentAlignment: go.Spot.Center,
+          padding: 30,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              fill: "#ffffff",
+              strokeWidth: 1,
+              stroke: "rgba(148, 163, 184, 0.5)",
+              spot1: go.Spot.TopLeft,
+              spot2: go.Spot.BottomRight,
+              shadowVisible: true,
+              shadowColor: "rgba(15, 23, 42, 0.18)",
+              shadowOffset: new go.Point(0, 3),
+              shadowBlur: 8
+            },
+            new go.Binding("fill", "color", (c) => go.Brush.mix("#ffffff", c || "#2563eb", 0.18))
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: new go.Margin(6, 10, 6, 10),
+              font: "600 12px 'Segoe UI'",
+              stroke: "#1f2937",
+              maxSize: new go.Size(140, NaN),
+              wrap: go.TextBlock.WrapFit
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          { routing: go.Link.Orthogonal, corner: 8, selectable: false },
+          $(go.Shape, { strokeWidth: 1.1, stroke: "rgba(148, 163, 184, 0.5)" })
+        );
+
+        diagram.model = new go.TreeModel(nodeDataArray);
+
+        const stats = document.getElementById("stats");
+        if (stats) {
+          const linkCount = nodeDataArray.length - 1;
+          stats.textContent = `节点数：${nodeDataArray.length} · 连接数：${linkCount}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/fishbone.html
+++ b/layouts/fishbone.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FishboneLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <script src="https://gojs.net/latest/extensions/FishboneLayout.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #0f172a 0%, #1e293b 45%, #020617 100%);
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 30px 16px 18px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 12px;
+        font-size: clamp(26px, 4vw, 38px);
+        letter-spacing: 0.05em;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 760px;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
+      main {
+        max-width: 1140px;
+        margin: 0 auto;
+        padding: 20px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .back-link {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 20px;
+        background: radial-gradient(circle at center, rgba(59, 130, 246, 0.18), rgba(15, 23, 42, 0.94));
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        box-shadow: 0 28px 64px rgba(15, 23, 42, 0.55);
+      }
+
+      .legend {
+        margin-top: 20px;
+        padding: 18px 20px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #bfdbfe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>FishboneLayout 示例</h1>
+      <p>
+        FishboneLayout（鱼骨图）使用脊柱式排布梳理交付缺陷的根因。示例中以 50 个节点呈现六大维度及其细分因素，帮助快速定位问题归属。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span id="stats">节点数：0 · 连接数：0</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="FishboneLayout 示例"></div>
+      <div class="legend">
+        <div><strong>主干方向：</strong>从左至右表示问题脊柱，顶端为核心问题，鱼骨分支展示原因维度。</div>
+        <div><strong>分支主题：</strong>每个维度包含 7-8 个叶子节点，总计 50 个要素，突出排查细节。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const rootKey = "root";
+        const categories = [
+          {
+            key: "人员",
+            label: "人员能力",
+            color: "#38bdf8",
+            leaves: [
+              "新人培训",
+              "技能矩阵",
+              "值班交接",
+              "双人校验",
+              "专家评审",
+              "激励机制",
+              "职业发展",
+              "团队士气"
+            ]
+          },
+          {
+            key: "流程",
+            label: "流程制度",
+            color: "#818cf8",
+            leaves: [
+              "需求澄清",
+              "变更控制",
+              "发布窗口",
+              "回滚方案",
+              "值守流程",
+              "复盘机制",
+              "合规检查"
+            ]
+          },
+          {
+            key: "工具",
+            label: "工具平台",
+            color: "#f472b6",
+            leaves: [
+              "流水线",
+              "自动化测试",
+              "监控看板",
+              "日志追踪",
+              "告警联动",
+              "数据联邦",
+              "知识库"
+            ]
+          },
+          {
+            key: "环境",
+            label: "环境依赖",
+            color: "#34d399",
+            leaves: [
+              "多机房部署",
+              "容量规划",
+              "网络冗余",
+              "数据库主从",
+              "中间件升级",
+              "变更演练",
+              "灾备切换"
+            ]
+          },
+          {
+            key: "数据",
+            label: "数据质量",
+            color: "#facc15",
+            leaves: [
+              "指标口径",
+              "口径对齐",
+              "数据清洗",
+              "采集延迟",
+              "归档策略",
+              "权限隔离",
+              "审计追溯"
+            ]
+          },
+          {
+            key: "协同",
+            label: "协同机制",
+            color: "#22d3ee",
+            leaves: [
+              "例会节奏",
+              "需求对齐",
+              "跨部门群",
+              "共享文档",
+              "问题追踪",
+              "升级通道",
+              "客户反馈"
+            ]
+          }
+        ];
+
+        const nodes = [
+          {
+            key: rootKey,
+            text: "线上缺陷激增",
+            color: "#f97316",
+            weight: "Bold",
+            size: 18
+          }
+        ];
+
+        let linkCount = 0;
+
+        categories.forEach((category) => {
+          nodes.push({
+            key: category.key,
+            parent: rootKey,
+            text: category.label,
+            color: category.color,
+            weight: "Bold",
+            size: 16
+          });
+          linkCount += 1;
+
+          category.leaves.forEach((leaf, index) => {
+            const leafKey = `${category.key}-${index}`;
+            nodes.push({
+              key: leafKey,
+              parent: category.key,
+              text: leaf,
+              color: category.color
+            });
+            linkCount += 1;
+          });
+        });
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: new FishboneLayout({
+            angle: 0,
+            layerSpacing: 32,
+            nodeSpacing: 24
+          }),
+          initialAutoScale: go.Diagram.Uniform,
+          allowZoom: true,
+          padding: 20,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              fill: "rgba(15, 23, 42, 0.88)",
+              stroke: "rgba(148, 163, 184, 0.3)",
+              strokeWidth: 1,
+              spot1: go.Spot.TopLeft,
+              spot2: go.Spot.BottomRight
+            },
+            new go.Binding("fill", "color", (c) => (c ? go.Brush.mix("#0f172a", c, 0.7) : "rgba(15, 23, 42, 0.88)"))
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              stroke: "#e2e8f0",
+              font: "12px 'Segoe UI'",
+              wrap: go.TextBlock.WrapFit,
+              maxSize: new go.Size(140, NaN)
+            },
+            new go.Binding("text", "text"),
+            new go.Binding("font", "size", (s, data) => {
+              const weight = data.weight ? `${data.weight} ` : "";
+              const size = s || 12;
+              return `${weight}${size}px 'Segoe UI'`;
+            })
+          )
+        );
+
+        diagram.linkTemplate = $(
+          FishboneLink,
+          {
+            selectable: false
+          },
+          $(go.Shape, { stroke: "rgba(148, 163, 184, 0.65)", strokeWidth: 1.4 })
+        );
+
+        diagram.model = new go.TreeModel({
+          nodeDataArray: nodes
+        });
+
+        const stats = document.getElementById("stats");
+        if (stats) {
+          stats.textContent = `节点数：${nodes.length} · 连接数：${linkCount}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/force-directed.html
+++ b/layouts/force-directed.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ForceDirectedLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background-color: #0f172a;
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 24px 16px;
+        text-align: center;
+        background: radial-gradient(circle at top, rgba(59, 130, 246, 0.35), transparent 65%),
+          #0f172a;
+      }
+
+      header h1 {
+        margin: 0 0 8px;
+        font-size: clamp(26px, 4vw, 36px);
+        letter-spacing: 0.04em;
+      }
+
+      header p {
+        margin: 0;
+        color: rgba(226, 232, 240, 0.78);
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 16px 16px 48px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .back-link {
+        color: #93c5fd;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 18px;
+        background: radial-gradient(circle at center, rgba(59, 130, 246, 0.12), transparent 70%),
+          rgba(15, 23, 42, 0.88);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+      }
+
+      .legend {
+        margin-top: 18px;
+        padding: 16px 18px;
+        border-radius: 12px;
+        background: rgba(15, 23, 42, 0.78);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        display: grid;
+        gap: 8px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #bfdbfe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>ForceDirectedLayout 示例</h1>
+      <p>基于 50 个节点的复杂网络，通过力导向算法呈现自然舒展的结构。</p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：150</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="ForceDirectedLayout 示例"></div>
+      <div class="legend">
+        <div><strong>节点颜色</strong>：按社群编号着色，突出社群分布</div>
+        <div><strong>连接</strong>：包含环形主干与跨社群连接，模拟稠密关系网络</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const colors = ["#60a5fa", "#a855f7", "#34d399", "#f87171", "#facc15"];
+        const nodeCount = 50;
+        const nodes = Array.from({ length: nodeCount }, (_, i) => ({
+          key: i,
+          text: `节点 ${i + 1}`,
+          group: i % colors.length,
+          fill: colors[i % colors.length]
+        }));
+
+        const links = [];
+        for (let i = 0; i < nodeCount; i++) {
+          const next = (i + 1) % nodeCount;
+          const chord = (i + 5) % nodeCount;
+          const longChord = (i + 11) % nodeCount;
+          links.push({ from: i, to: next });
+          if (i !== chord) links.push({ from: i, to: chord });
+          if (i !== longChord) links.push({ from: i, to: longChord });
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.ForceDirectedLayout, {
+            defaultSpringLength: 120,
+            defaultElectricalCharge: 150
+          }),
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "Circle",
+            {
+              strokeWidth: 0,
+              fill: "#1e293b",
+              desiredSize: new go.Size(42, 42)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 4,
+              stroke: "#0f172a",
+              font: "bold 12px 'Segoe UI'",
+              background: "rgba(248, 250, 252, 0.9)",
+              maxSize: new go.Size(58, NaN)
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            curve: go.Link.Bezier,
+            adjusting: go.Link.Stretch,
+            opacity: 0.8,
+            selectable: false
+          },
+          $(go.Shape, {
+            strokeWidth: 1.5,
+            stroke: "rgba(148, 163, 184, 0.65)"
+          })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/grid.html
+++ b/layouts/grid.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GridLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(120deg, #0f172a 0%, #082f49 100%);
+        color: #e0f2fe;
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 30px 16px 18px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 36px);
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 620px;
+        color: rgba(191, 219, 254, 0.9);
+        line-height: 1.6;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 16px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 18px;
+        border: 1px solid rgba(125, 211, 252, 0.4);
+        background: rgba(8, 47, 73, 0.75);
+        box-shadow: 0 32px 80px rgba(8, 47, 73, 0.5);
+      }
+
+      .legend {
+        margin-top: 18px;
+        display: grid;
+        gap: 10px;
+        padding: 18px;
+        border-radius: 14px;
+        background: rgba(8, 47, 73, 0.7);
+        border: 1px solid rgba(14, 165, 233, 0.4);
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #7dd3fc;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>GridLayout 示例</h1>
+      <p>
+        将 49 个节点按照 7×7 的网格对齐，并通过行列邻接连线展示矩阵拓扑，适合查看规则结构中的连通性。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：49 · 连接数：84</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="GridLayout 示例"></div>
+      <div class="legend">
+        <div><strong>颜色梯度</strong>：按行使用由浅至深的蓝色系，便于识别行信息。</div>
+        <div><strong>连线设计</strong>：链接相邻行列节点，突出网格拓扑结构。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const rows = 7;
+        const cols = 7;
+        const palette = ["#bae6fd", "#7dd3fc", "#38bdf8", "#0ea5e9", "#0284c7", "#0369a1", "#0f172a"];
+
+        const nodes = [];
+        for (let r = 0; r < rows; r++) {
+          for (let c = 0; c < cols; c++) {
+            const key = r * cols + c;
+            nodes.push({
+              key,
+              text: `(${r + 1}, ${c + 1})`,
+              row: r,
+              col: c,
+              fill: palette[r]
+            });
+          }
+        }
+
+        const links = [];
+        for (let r = 0; r < rows; r++) {
+          for (let c = 0; c < cols; c++) {
+            const from = r * cols + c;
+            if (c < cols - 1) {
+              links.push({ from, to: from + 1 });
+            }
+            if (r < rows - 1) {
+              links.push({ from, to: from + cols });
+            }
+          }
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.GridLayout, {
+            wrappingColumn: cols,
+            spacing: new go.Size(50, 40),
+            alignment: go.GridLayout.Position
+          }),
+          allowHorizontalScroll: false,
+          allowVerticalScroll: false,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              strokeWidth: 0,
+              fill: "#0ea5e9",
+              desiredSize: new go.Size(72, 44)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              font: "bold 13px 'Segoe UI'",
+              stroke: "#082f49"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 4,
+            selectable: false,
+            opacity: 0.85
+          },
+          $(go.Shape, { strokeWidth: 1.2, stroke: "rgba(125, 211, 252, 0.7)" })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/layered-digraph.html
+++ b/layouts/layered-digraph.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LayeredDigraphLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+        color: #0f172a;
+      }
+
+      header {
+        padding: 32px 16px 20px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 36px);
+        color: #1f2937;
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 640px;
+        line-height: 1.6;
+        color: #4b5563;
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 16px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #2563eb;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: #ffffff;
+        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
+      }
+
+      .legend {
+        margin-top: 20px;
+        display: grid;
+        gap: 10px;
+        padding: 18px 20px;
+        border-radius: 14px;
+        background: rgba(226, 232, 240, 0.6);
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #1f2937;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>LayeredDigraphLayout 示例</h1>
+      <p>
+        以 5 层流程结构展示 50 个节点，强调方向性关系以及跨层交叉链接，模拟数据管道或业务流程图。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：120</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="LayeredDigraphLayout 示例"></div>
+      <div class="legend">
+        <div><strong>节点配色</strong>：根据层级使用渐变色，方便识别流程进度。</div>
+        <div><strong>连线设计</strong>：除顺层连线外加入跨层跳线，用以展示复杂依赖。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const layerCount = 5;
+        const nodesPerLayer = 10;
+        const colors = ["#bfdbfe", "#93c5fd", "#60a5fa", "#3b82f6", "#2563eb"];
+
+        const nodes = [];
+        for (let layer = 0; layer < layerCount; layer++) {
+          for (let index = 0; index < nodesPerLayer; index++) {
+            const key = layer * nodesPerLayer + index;
+            nodes.push({
+              key,
+              text: `L${layer + 1}-${index + 1}`,
+              layer,
+              fill: colors[layer]
+            });
+          }
+        }
+
+        const links = [];
+        for (let layer = 0; layer < layerCount; layer++) {
+          for (let index = 0; index < nodesPerLayer; index++) {
+            const from = layer * nodesPerLayer + index;
+            if (layer < layerCount - 1) {
+              const nextLayerStart = (layer + 1) * nodesPerLayer;
+              const target1 = nextLayerStart + (index % nodesPerLayer);
+              const target2 = nextLayerStart + ((index + 3) % nodesPerLayer);
+              links.push({ from, to: target1 });
+              if (target2 !== target1) links.push({ from, to: target2 });
+            }
+            if (layer < layerCount - 2 && index % 2 === 0) {
+              const skipLayerStart = (layer + 2) * nodesPerLayer;
+              const target = skipLayerStart + ((index + layer) % nodesPerLayer);
+              links.push({ from, to: target });
+            }
+          }
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.LayeredDigraphLayout, {
+            direction: 0,
+            layerSpacing: 90,
+            columnSpacing: 16,
+            setsPortSpots: false
+          }),
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              strokeWidth: 0,
+              fill: "#e2e8f0",
+              desiredSize: new go.Size(120, 42)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              font: "bold 13px 'Segoe UI'",
+              stroke: "#1f2937"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 6,
+            fromEndSegmentLength: 10,
+            toEndSegmentLength: 10,
+            selectable: false
+          },
+          $(go.Shape, { strokeWidth: 1.5, stroke: "#1d4ed8" })
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/packed.html
+++ b/layouts/packed.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PackedLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <script src="https://gojs.net/latest/extensions/PackedLayout.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(145deg, #111827 0%, #0f172a 35%, #020617 100%);
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 30px 16px 18px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 12px;
+        font-size: clamp(26px, 4vw, 38px);
+        letter-spacing: 0.05em;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 720px;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.8);
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 20px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .back-link {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 20px;
+        background: radial-gradient(circle at center, rgba(56, 189, 248, 0.18), rgba(15, 23, 42, 0.95));
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 30px 70px rgba(2, 6, 23, 0.6);
+      }
+
+      .legend {
+        margin-top: 20px;
+        padding: 18px 20px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.26);
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #bfdbfe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>PackedLayout 示例</h1>
+      <p>
+        PackedLayout 将 50 个圆形节点紧凑排布在椭圆形空间内，展示多产品线在空间上的均衡分布，并通过连线体现跨集群协作。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span id="stats">节点数：0 · 连接数：0</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="PackedLayout 示例"></div>
+      <div class="legend">
+        <div><strong>颜色分组：</strong>节点按事业群划分为五个集群，尺寸大小反映该集群的活跃度。</div>
+        <div><strong>跨集群协作：</strong>对角虚线展示关键协作关系，观察 PackedLayout 在保持紧凑的同时如何留出路径。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const groups = [
+          { name: "智能硬件", color: "#38bdf8" },
+          { name: "云服务", color: "#818cf8" },
+          { name: "行业解决", color: "#f472b6" },
+          { name: "生态合作", color: "#34d399" },
+          { name: "数据产品", color: "#facc15" }
+        ];
+
+        const nodes = [];
+        const links = [];
+        let key = 0;
+
+        groups.forEach((group, groupIndex) => {
+          for (let i = 0; i < 10; i++, key++) {
+            const radius = 56 - (i % 4) * 8;
+            nodes.push({
+              key,
+              text: `${group.name} ${i + 1}`,
+              color: group.color,
+              size: radius,
+              cluster: group.name
+            });
+
+            if (i > 0) {
+              links.push({ from: key - 1, to: key, category: "intra" });
+            }
+          }
+        });
+
+        const bridgeLinks = [
+          [2, 18],
+          [6, 27],
+          [13, 35],
+          [21, 8],
+          [32, 44],
+          [38, 4],
+          [47, 15]
+        ];
+
+        bridgeLinks.forEach(([from, to]) => {
+          links.push({ from, to, category: "bridge" });
+        });
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: new go.PackedLayout({
+            packShape: go.PackShape.Elliptical,
+            packMode: go.PackMode.Fit,
+            aspectRatio: 1,
+            spacing: 16,
+            sortMode: go.SortMode.Area,
+            sortOrder: go.SortOrder.Descending
+          }),
+          initialAutoScale: go.Diagram.Uniform,
+          allowZoom: true,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Spot",
+          { locationSpot: go.Spot.Center },
+          $(
+            go.Shape,
+            "Circle",
+            {
+              stroke: "rgba(15, 23, 42, 0.2)",
+              strokeWidth: 1
+            },
+            new go.Binding("fill", "color"),
+            new go.Binding("desiredSize", "size", (s) => new go.Size(s, s))
+          ),
+          $(
+            go.TextBlock,
+            {
+              stroke: "#0f172a",
+              background: "rgba(248, 250, 252, 0.9)",
+              font: "bold 12px 'Segoe UI'",
+              margin: 4,
+              wrap: go.TextBlock.WrapFit,
+              maxSize: new go.Size(80, NaN)
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        const intraTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.AvoidsNodes,
+            corner: 6,
+            selectable: false,
+            opacity: 0.65
+          },
+          $(go.Shape, { strokeWidth: 1.5, stroke: "rgba(148, 163, 184, 0.6)" })
+        );
+        diagram.linkTemplate = intraTemplate;
+        diagram.linkTemplateMap.add("intra", intraTemplate);
+
+        diagram.linkTemplateMap.add(
+          "bridge",
+          $(
+            go.Link,
+            {
+              curve: go.Link.Bezier,
+              adjusting: go.Link.End,
+              selectable: false,
+              opacity: 0.75
+            },
+            $(go.Shape, {
+              strokeWidth: 1.4,
+              stroke: "rgba(56, 189, 248, 0.65)",
+              strokeDashArray: [6, 3]
+            }),
+            $(go.Shape, { toArrow: "Standard", fill: "rgba(56, 189, 248, 0.78)", stroke: null, scale: 0.9 })
+          )
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+
+        const stats = document.getElementById("stats");
+        if (stats) {
+          stats.textContent = `节点数：${nodes.length} · 连接数：${links.length}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/parallel.html
+++ b/layouts/parallel.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ParallelLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <script src="https://gojs.net/latest/extensions/ParallelLayout.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #0f172a 0%, #1e293b 40%, #1e293b 100%);
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 30px 16px 18px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 10px;
+        font-size: clamp(26px, 4vw, 38px);
+        letter-spacing: 0.06em;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 720px;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
+      main {
+        max-width: 1140px;
+        margin: 0 auto;
+        padding: 20px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .back-link {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 18px;
+        background: radial-gradient(circle at center, rgba(56, 189, 248, 0.16), rgba(15, 23, 42, 0.95));
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 28px 62px rgba(15, 23, 42, 0.55);
+      }
+
+      .legend {
+        margin-top: 20px;
+        padding: 18px 20px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.26);
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #bfdbfe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>ParallelLayout 示例</h1>
+      <p>
+        通过 ParallelLayout 将 4 条并行流程展开，展示从统一分流节点出发的 50 个步骤如何分支执行、最终在合流节点完成评审。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span id="stats">节点数：0 · 连接数：0</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="ParallelLayout 示例"></div>
+      <div class="legend">
+        <div><strong>分支说明：</strong>不同颜色代表市场、产品、交付、运营四条执行支路，全部继承同一个分流节点。</div>
+        <div><strong>交叉依赖：</strong>横向虚线记录关键协作节点，体现并行流程之间的同步动作。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const lanes = [
+          { id: "M", name: "市场验证", color: "#38bdf8" },
+          { id: "P", name: "产品打磨", color: "#f472b6" },
+          { id: "D", name: "交付准备", color: "#34d399" },
+          { id: "O", name: "运营铺排", color: "#facc15" }
+        ];
+
+        const tasksPerLane = 12;
+        const splitKey = "Split";
+        const mergeKey = "Merge";
+
+        const nodes = [
+          { key: splitKey, category: "Split", text: "全局分流", color: "#38bdf8" },
+          { key: mergeKey, category: "Merge", text: "统一验收", color: "#34d399" }
+        ];
+
+        const links = [];
+
+        lanes.forEach((lane) => {
+          for (let i = 0; i < tasksPerLane; i++) {
+            const key = `${lane.id}-${i}`;
+            nodes.push({
+              key,
+              text: `${lane.name} ${i + 1}`,
+              lane: lane.name,
+              color: lane.color
+            });
+
+            if (i === 0) {
+              links.push({ from: splitKey, to: key });
+            } else {
+              links.push({ from: `${lane.id}-${i - 1}`, to: key });
+            }
+
+            if (i === tasksPerLane - 1) {
+              links.push({ from: key, to: mergeKey });
+            }
+          }
+        });
+
+        const syncPairs = [
+          ["M-3", "P-2"],
+          ["P-5", "D-4"],
+          ["D-6", "O-5"],
+          ["M-8", "D-7"],
+          ["P-9", "O-8"],
+          ["D-10", "M-11"],
+          ["O-9", "P-10"]
+        ];
+
+        syncPairs.forEach(([from, to]) => {
+          links.push({ from, to, category: "sync" });
+        });
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: new ParallelLayout({
+            layerSpacing: 40,
+            nodeSpacing: 18
+          }),
+          "undoManager.isEnabled": false,
+          initialAutoScale: go.Diagram.Uniform,
+          allowZoom: true,
+          padding: 20
+        });
+
+        function createNodeTemplate(fill, shape, size) {
+          return $(
+            go.Node,
+            "Auto",
+            { locationSpot: go.Spot.Center },
+            $(
+              go.Shape,
+              shape,
+              {
+                fill,
+                stroke: "rgba(15, 23, 42, 0.2)",
+                strokeWidth: 0,
+                desiredSize: size
+              },
+              new go.Binding("fill", "color", (c) => c || fill)
+            ),
+            $(
+              go.TextBlock,
+              {
+                margin: 6,
+                stroke: "#0f172a",
+                font: "bold 12px 'Segoe UI'",
+                background: "rgba(248, 250, 252, 0.9)",
+                maxSize: new go.Size(130, NaN)
+              },
+              new go.Binding("text", "text")
+            )
+          );
+        }
+
+        diagram.nodeTemplate = createNodeTemplate("rgba(30, 64, 175, 0.28)", "RoundedRectangle", new go.Size(140, 54));
+        diagram.nodeTemplateMap.add(
+          "Split",
+          createNodeTemplate("#38bdf8", "Diamond", new go.Size(44, 44))
+        );
+        diagram.nodeTemplateMap.add(
+          "Merge",
+          createNodeTemplate("#34d399", "Circle", new go.Size(44, 44))
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 6,
+            selectable: false,
+            fromSpot: go.Spot.Right,
+            toSpot: go.Spot.Left
+          },
+          $(go.Shape, { strokeWidth: 1.8, stroke: "rgba(148, 163, 184, 0.7)" })
+        );
+
+        diagram.linkTemplateMap.add(
+          "sync",
+          $(
+            go.Link,
+            {
+              curve: go.Link.Bezier,
+              adjusting: go.Link.End,
+              selectable: false,
+              opacity: 0.75
+            },
+            $(go.Shape, {
+              strokeWidth: 1.4,
+              stroke: "rgba(56, 189, 248, 0.65)",
+              strokeDashArray: [6, 3]
+            }),
+            $(go.Shape, { toArrow: "Standard", fill: "rgba(56, 189, 248, 0.75)", stroke: null, scale: 0.9 })
+          )
+        );
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+
+        const stats = document.getElementById("stats");
+        if (stats) {
+          stats.textContent = `节点数：${nodes.length} · 连接数：${links.length}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/radial.html
+++ b/layouts/radial.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RadialLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <script src="https://gojs.net/latest/extensions/RadialLayout.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: radial-gradient(circle at top, #1e3a8a 0%, #0f172a 45%, #020617 100%);
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 32px 16px 20px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 10px;
+        font-size: clamp(26px, 4vw, 38px);
+        letter-spacing: 0.05em;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 680px;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.8);
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 18px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 14px;
+      }
+
+      .back-link {
+        color: #60a5fa;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 20px;
+        background: radial-gradient(circle at center, rgba(59, 130, 246, 0.18), rgba(15, 23, 42, 0.95));
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 28px 60px rgba(2, 6, 23, 0.6);
+      }
+
+      .legend {
+        margin-top: 20px;
+        padding: 18px 20px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #bfdbfe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>RadialLayout 示例</h1>
+      <p>
+        以核心节点为中心的同心层结构，展示 50 个节点的辐射式扩散关系，适合呈现知识地图或职能辐射网络。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span id="stats">节点数：0 · 连接数：0</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="RadialLayout 示例"></div>
+      <div class="legend">
+        <div><strong>层级划分</strong>：按照距离中心的层数分配半径，越靠外表示与核心概念距离越远。</div>
+        <div><strong>配色策略</strong>：不同射线分支使用渐变色系，强化主题分组效果。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const colors = ["#38bdf8", "#818cf8", "#a855f7", "#f97316", "#22c55e", "#facc15"];
+        const nodeDataArray = [{ key: "核心", text: "核心主题", color: "#f97316" }];
+
+        const branchConfigs = [
+          { label: "市场洞察", color: colors[0], leafCounts: [2, 2, 2] },
+          { label: "产品路线", color: colors[1], leafCounts: [3, 2] },
+          { label: "渠道策略", color: colors[2], leafCounts: [2, 1] },
+          { label: "实施计划", color: colors[3], leafCounts: [3, 2, 2] },
+          { label: "团队协同", color: colors[4], leafCounts: [2, 2] },
+          { label: "度量反馈", color: colors[5], leafCounts: [2, 2] }
+        ];
+
+        const branchBaseTexts = [
+          ["趋势洞察", "用户研究", "竞品观测"],
+          ["阶段规划", "能力演进"],
+          ["渠道拓展", "伙伴共建"],
+          ["里程碑", "资源匹配", "风险防控"],
+          ["沟通机制", "协作流程"],
+          ["指标设计", "复盘优化"]
+        ];
+
+        const detailBaseTexts = [
+          ["社交舆情", "行业报告", "关键词监控"],
+          ["深访画像", "问卷回收", "体验反馈"],
+          ["竞品矩阵", "差异亮点", "策略比较"],
+          ["发布节奏", "功能演进", "技术栈"],
+          ["能力图谱", "实验沙箱", "创新储备"],
+          ["渠道评分", "联合营销", "区域运营"],
+          ["生态伙伴", "代理体系", "培训计划"],
+          ["路线图", "执行表"],
+          ["预算评估", "人力安排", "外包协同"],
+          ["风险识别", "预案演练"],
+          ["例会节奏", "共识库", "透明看板"],
+          ["工具整合", "跨部门对齐"],
+          ["北极星指标", "仪表盘"],
+          ["复盘例会", "试验管理"],
+          ["持续改进", "经验沉淀"]
+        ];
+
+        let detailIndex = 0;
+        branchConfigs.forEach((config, branchIndex) => {
+          const branchKey = `B${branchIndex}`;
+          nodeDataArray.push({ key: branchKey, parent: "核心", text: config.label, color: config.color });
+
+          const topics = branchBaseTexts[branchIndex] || [];
+          config.leafCounts.forEach((leafCount, topicIndex) => {
+            const topicKey = `${branchKey}-T${topicIndex}`;
+            const topicText = topics[topicIndex] || `主题 ${branchIndex + 1}-${topicIndex + 1}`;
+            nodeDataArray.push({ key: topicKey, parent: branchKey, text: topicText, color: config.color });
+
+            for (let leaf = 0; leaf < leafCount; leaf++) {
+              const detailKey = `${topicKey}-D${leaf}`;
+              const baseText = detailBaseTexts[detailIndex] || [];
+              const detailText = baseText[leaf] || `要点 ${branchIndex + 1}-${topicIndex + 1}-${leaf + 1}`;
+              nodeDataArray.push({
+                key: detailKey,
+                parent: topicKey,
+                text: detailText,
+                color: config.color
+              });
+            }
+            detailIndex = Math.min(detailIndex + 1, detailBaseTexts.length - 1);
+          });
+        });
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: new RadialLayout({ layerThickness: 120, maxLayers: 4 }),
+          padding: 32,
+          "undoManager.isEnabled": false,
+          initialAutoScale: go.Diagram.Uniform
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              fill: "rgba(15, 23, 42, 0.9)",
+              stroke: "rgba(148, 163, 184, 0.4)",
+              strokeWidth: 1,
+              spot1: go.Spot.TopLeft,
+              spot2: go.Spot.BottomRight
+            },
+            new go.Binding("fill", "color", (c) => go.Brush.mix("#0f172a", c || "#38bdf8", 0.75))
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: new go.Margin(6, 8, 6, 8),
+              stroke: "#e2e8f0",
+              font: "600 12px 'Segoe UI'",
+              maxSize: new go.Size(120, NaN),
+              wrap: go.TextBlock.WrapFit
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          { routing: go.Link.Normal, curve: go.Link.Bezier, selectable: false, opacity: 0.8 },
+          $(go.Shape, { strokeWidth: 1.1, stroke: "rgba(148, 163, 184, 0.35)" })
+        );
+
+        diagram.model = new go.TreeModel(nodeDataArray);
+
+        const rootNode = diagram.findNodeForKey("核心");
+        if (rootNode) {
+          diagram.layout.root = rootNode;
+          diagram.centerRect(rootNode.actualBounds);
+        }
+
+        const stats = document.getElementById("stats");
+        if (stats) {
+          const linkCount = nodeDataArray.length - 1;
+          stats.textContent = `节点数：${nodeDataArray.length} · 连接数：${linkCount}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/serpentine.html
+++ b/layouts/serpentine.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SerpentineLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <script src="https://gojs.net/latest/extensions/SerpentineLayout.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #111827 0%, #1f2937 45%, #0f172a 100%);
+        color: #f8fafc;
+      }
+
+      header {
+        padding: 30px 16px 20px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 12px;
+        font-size: clamp(26px, 4vw, 38px);
+        letter-spacing: 0.05em;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 720px;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 18px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 16px;
+      }
+
+      .back-link {
+        color: #60a5fa;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 620px;
+        border-radius: 18px;
+        background: radial-gradient(circle at center, rgba(30, 64, 175, 0.28), rgba(15, 23, 42, 0.94));
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 28px 64px rgba(15, 23, 42, 0.58);
+      }
+
+      .legend {
+        margin-top: 20px;
+        padding: 18px 20px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.72);
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #bfdbfe;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>SerpentineLayout 示例</h1>
+      <p>
+        演示 50 个节点沿蛇形路线推进的项目排期，SerpentineLayout 会根据视口宽度自动换行，便于观察连贯的阶段推进节奏与跨阶段依赖。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span id="stats">节点数：0 · 连接数：0</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="SerpentineLayout 示例"></div>
+      <div class="legend">
+        <div><strong>布局特点：</strong>蛇形排布让长链路不至于过宽，默认右进左回，适合可视化冲刺节奏。</div>
+        <div><strong>连线设计：</strong>节点之间按阶段顺序连接，并额外标注关键依赖，便于识别跨周期影响。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const phasePalette = ["#38bdf8", "#818cf8", "#f472b6", "#34d399", "#facc15"];
+        const milestoneNames = [
+          "需求对齐",
+          "范围冻结",
+          "方案设计",
+          "接口联调",
+          "灰度试点"
+        ];
+
+        const nodeCount = 50;
+        const nodes = Array.from({ length: nodeCount }, (_, i) => {
+          const phase = Math.floor(i / 10);
+          return {
+            key: i,
+            text: `${milestoneNames[phase % milestoneNames.length]} · ${i + 1}`,
+            color: phasePalette[phase % phasePalette.length]
+          };
+        });
+
+        const links = [];
+        for (let i = 0; i < nodeCount - 1; i++) {
+          links.push({ from: i, to: i + 1 });
+        }
+
+        const dependencyPairs = [
+          [0, 5],
+          [6, 12],
+          [11, 18],
+          [17, 24],
+          [23, 30],
+          [29, 36],
+          [35, 42],
+          [41, 48]
+        ];
+
+        dependencyPairs.forEach(([from, to]) => {
+          if (to < nodeCount) {
+            links.push({ from, to, category: "dependency" });
+          }
+        });
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: new SerpentineLayout({
+            spacing: new go.Size(80, 48),
+            wrap: NaN
+          }),
+          padding: new go.Margin(24, 32, 24, 32),
+          "undoManager.isEnabled": false,
+          allowZoom: true,
+          initialAutoScale: go.Diagram.Uniform
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              fill: "rgba(15, 23, 42, 0.8)",
+              strokeWidth: 0,
+              desiredSize: new go.Size(140, 48)
+            },
+            new go.Binding("fill", "color", (c) => go.Brush.mix("#0f172a", c, 0.7))
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              stroke: "#0f172a",
+              font: "bold 12px 'Segoe UI'",
+              background: "rgba(248, 250, 252, 0.88)",
+              wrap: go.TextBlock.WrapFit,
+              maxSize: new go.Size(130, NaN)
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        const dependencyStroke = "rgba(96, 165, 250, 0.55)";
+
+        diagram.linkTemplateMap.add(
+          "dependency",
+          $(
+            go.Link,
+            {
+              curve: go.Link.Bezier,
+              adjusting: go.Link.End,
+              selectable: false,
+              opacity: 0.75
+            },
+            $(go.Shape, { strokeWidth: 1.6, stroke: dependencyStroke, strokeDashArray: [6, 3] }),
+            $(go.Shape, { toArrow: "Standard", fill: dependencyStroke, stroke: null, scale: 0.9 })
+          )
+        );
+
+        const mainTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 6,
+            selectable: false,
+            fromSpot: go.Spot.Right,
+            toSpot: go.Spot.Left,
+            layerName: "Background"
+          },
+          $(go.Shape, { strokeWidth: 2.4, stroke: "rgba(148, 163, 184, 0.6)" }),
+          $(go.Shape, { toArrow: "Standard", fill: "rgba(148, 163, 184, 0.8)", stroke: null })
+        );
+        diagram.linkTemplate = mainTemplate;
+        diagram.linkTemplateMap.add("", mainTemplate);
+
+        diagram.model = new go.GraphLinksModel(nodes, links);
+
+        const stats = document.getElementById("stats");
+        if (stats) {
+          stats.textContent = `节点数：${nodes.length} · 连接数：${links.length}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/spiral.html
+++ b/layouts/spiral.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SpiralLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <script src="https://gojs.net/latest/extensions/SpiralLayout.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #111827 0%, #020617 100%);
+        color: #f1f5f9;
+      }
+
+      header {
+        padding: 30px 16px 18px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 8px;
+        font-size: clamp(26px, 4vw, 38px);
+        letter-spacing: 0.06em;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 720px;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 18px 16px 60px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 14px;
+      }
+
+      .back-link {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 24px;
+        background: radial-gradient(circle at center, rgba(56, 189, 248, 0.2), rgba(17, 24, 39, 0.94));
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 26px 70px rgba(2, 6, 23, 0.65);
+      }
+
+      .legend {
+        margin-top: 20px;
+        padding: 18px 20px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.75);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        display: grid;
+        gap: 10px;
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #7dd3fc;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>SpiralLayout 示例</h1>
+      <p>
+        将 50 个节点排列成旋臂式链路，模拟知识或任务的渐进推进，同时通过跨臂连接展示关联跳跃。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span id="stats">节点数：0 · 连接数：0</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="SpiralLayout 示例"></div>
+      <div class="legend">
+        <div><strong>旋臂节奏</strong>：每个节点按照螺旋节奏递增半径和角度，形成紧凑而有张力的视觉动线。</div>
+        <div><strong>跨臂引用</strong>：额外的跨阶链接连接不同转臂，强调阶段之间的前后呼应与复用。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const palette = ["#38bdf8", "#818cf8", "#f97316", "#22c55e", "#f472b6"];
+        const nodeCount = 50;
+        const nodeDataArray = Array.from({ length: nodeCount }, (_, index) => ({
+          key: index,
+          text: `节点 ${index + 1}`,
+          fill: palette[index % palette.length],
+          band: Math.floor(index / 10)
+        }));
+
+        const linkDataArray = [];
+        for (let i = 0; i < nodeCount - 1; i++) {
+          linkDataArray.push({ from: i, to: i + 1, category: "chain" });
+          if (i % 5 === 0 && i + 6 < nodeCount) {
+            linkDataArray.push({ from: i, to: i + 6, category: "jump" });
+          }
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: new SpiralLayout({ spacing: 65, radius: 20, clockwise: true }),
+          padding: 40,
+          initialAutoScale: go.Diagram.Uniform,
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "Circle",
+            {
+              strokeWidth: 0,
+              desiredSize: new go.Size(42, 42),
+              fill: "#1f2937"
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 4,
+              font: "600 12px 'Segoe UI'",
+              stroke: "#0f172a",
+              background: "rgba(248, 250, 252, 0.9)",
+              maxSize: new go.Size(56, NaN)
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplateMap.add(
+          "",
+          $(
+            go.Link,
+            { curve: go.Link.Bezier, selectable: false, layerName: "Background", opacity: 0.8 },
+            $(go.Shape, { strokeWidth: 1.2, stroke: "rgba(148, 163, 184, 0.45)" })
+          )
+        );
+
+        diagram.linkTemplateMap.add(
+          "jump",
+          $(
+            go.Link,
+            {
+              curve: go.Link.Bezier,
+              routing: go.Link.Orthogonal,
+              corner: 12,
+              opacity: 0.6,
+              selectable: false
+            },
+            $(go.Shape, { strokeWidth: 1.6, strokeDashArray: [6, 6], stroke: "rgba(56, 189, 248, 0.7)" })
+          )
+        );
+
+        diagram.model = new go.GraphLinksModel({
+          linkKeyProperty: "id",
+          nodeDataArray,
+          linkDataArray
+        });
+
+        const stats = document.getElementById("stats");
+        if (stats) {
+          stats.textContent = `节点数：${nodeDataArray.length} · 连接数：${linkDataArray.length}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/tree.html
+++ b/layouts/tree.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TreeLayout 示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: linear-gradient(160deg, #ecfeff 0%, #fef3c7 100%);
+        color: #0f172a;
+      }
+
+      header {
+        padding: 32px 16px 20px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(26px, 4vw, 36px);
+        color: #1f2937;
+      }
+
+      header p {
+        margin: 12px auto 0;
+        max-width: 600px;
+        line-height: 1.6;
+        color: #4b5563;
+      }
+
+      main {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 16px 16px 56px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+
+      .back-link {
+        color: #d97706;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 16px;
+        border: 1px solid rgba(234, 179, 8, 0.4);
+        background: rgba(255, 255, 255, 0.85);
+        box-shadow: 0 24px 60px rgba(217, 119, 6, 0.18);
+      }
+
+      .legend {
+        margin-top: 18px;
+        display: grid;
+        gap: 10px;
+        padding: 16px 18px;
+        border-radius: 12px;
+        background: rgba(253, 230, 138, 0.4);
+        border: 1px solid rgba(217, 119, 6, 0.32);
+        font-size: 14px;
+      }
+
+      .legend strong {
+        color: #b45309;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>TreeLayout 示例</h1>
+      <p>
+        自上而下展开的多层树形结构，包含 50 个节点，能够清晰展示配电网络或组织架构的层级关系。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <span>节点数：50 · 连接数：49</span>
+      </div>
+      <div id="diagramDiv" role="presentation" aria-label="TreeLayout 示例"></div>
+      <div class="legend">
+        <div><strong>节点配色</strong>：根据层级深度渐变，帮助区分不同层级。</div>
+        <div><strong>布局参数</strong>：使用 angle=90 的 TreeLayout，自上而下展开，每层保持均匀间距。</div>
+      </div>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const colors = ["#fde68a", "#fbbf24", "#f59e0b", "#d97706", "#b45309"];
+        const nodeCount = 50;
+        const nodes = [{ key: 0, text: "中心节点", level: 0, fill: colors[0] }];
+
+        for (let i = 1; i < nodeCount; i++) {
+          const parentIndex = Math.floor((i - 1) / 3);
+          const parent = nodes[parentIndex];
+          const level = Math.min(parent.level + 1, colors.length - 1);
+          nodes.push({
+            key: i,
+            parent: parent.key,
+            text: `节点 ${i + 1}`,
+            level,
+            fill: colors[level]
+          });
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.TreeLayout, {
+            angle: 90,
+            nodeSpacing: 24,
+            layerSpacing: 80
+          }),
+          "undoManager.isEnabled": false
+        });
+
+        diagram.nodeTemplate = $(
+          go.Node,
+          "Auto",
+          $(
+            go.Shape,
+            "RoundedRectangle",
+            {
+              fill: "#fde68a",
+              stroke: "rgba(180, 83, 9, 0.2)",
+              strokeWidth: 1,
+              desiredSize: new go.Size(110, 44)
+            },
+            new go.Binding("fill", "fill")
+          ),
+          $(
+            go.TextBlock,
+            {
+              margin: 6,
+              font: "bold 13px 'Segoe UI'",
+              stroke: "#78350f"
+            },
+            new go.Binding("text", "text")
+          )
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 6,
+            selectable: false
+          },
+          $(go.Shape, { strokeWidth: 1.5, stroke: "rgba(180, 83, 9, 0.6)" })
+        );
+
+        diagram.model = new go.TreeModel({ nodeDataArray: nodes });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- instantiate the DoubleTree demo with go.DoubleTreeLayout so the layout extension is found
- update the Packed demo to use go.PackedLayout and reference pack constants from the go namespace

## Testing
- not run (static HTML changes only)


------
https://chatgpt.com/codex/tasks/task_b_68cdfd82c5c88327b1ffb621fd774b27