### PR TITLE
Fix GoJS extension usage for PackedLayout and DoubleTree

### DIFF
--- a/layouts/double-tree.html
+++ b/layouts/double-tree.html
@@ -184,7 +184,7 @@
         buildSide(rightPlan, "right");
 
         const diagram = $(go.Diagram, "diagramDiv", {
-          layout: new go.DoubleTreeLayout({
+          layout: new DoubleTreeLayout({
             directionFunction: (node) => node.data && node.data.dir !== "left",
             bottomRightOptions: { nodeSpacing: 18, layerSpacing: 36 },
             topLeftOptions: { nodeSpacing: 18, layerSpacing: 36 },

--- a/layouts/packed.html
+++ b/layouts/packed.html
@@ -173,12 +173,12 @@
 
         const diagram = $(go.Diagram, "diagramDiv", {
           layout: new go.PackedLayout({
-            packShape: go.PackShape.Elliptical,
-            packMode: go.PackMode.Fit,
+            packShape: PackShape.Elliptical,
+            packMode: PackMode.Fit,
             aspectRatio: 1,
             spacing: 16,
-            sortMode: go.SortMode.Area,
-            sortOrder: go.SortOrder.Descending,
+            sortMode: SortMode.Area,
+            sortOrder: SortOrder.Descending,
           }),
           initialAutoScale: go.Diagram.Uniform,
           allowZoom: true,


### PR DESCRIPTION
## Summary
- update the PackedLayout demo to reference the extension-provided PackShape, PackMode, SortMode, and SortOrder globals
- construct the DoubleTree layout using the global DoubleTreeLayout class exposed by the GoJS extension

## Testing
- not run (HTML change only)


------
https://chatgpt.com/codex/tasks/task_b_68d13dd4c6288327871f29c353b6f844