### PR TITLE
Expand distribution network example

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,6 +250,14 @@
           </p>
           <span>查看示例</span>
         </a>
+        <a class="card" href="layouts/distribution-network.html">
+          <span class="badge">行业场景</span>
+          <h2>配电网监控示例</h2>
+          <p>
+            以 110kV 变电站为核心展示三条馈线与联络开关，并可交互模拟停电与负荷均衡，结合状态监测与统计面板体验运行管控流程。
+          </p>
+          <span>查看示例</span>
+        </a>
         <a class="card" href="layouts/circular.html">
           <span class="badge">GoJS 布局</span>
           <h2>CircularLayout</h2>

--- a/layouts/distribution-network.html
+++ b/layouts/distribution-network.html
@@ -1,0 +1,1396 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>配电网监控示例 | GoJS 布局画廊</title>
+    <script src="https://unpkg.com/gojs/release/go.js"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        color: #e2e8f0;
+        background: radial-gradient(circle at top, #1f2937 0%, #0f172a 45%, #020617 100%);
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 32px 16px 12px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0 0 12px;
+        font-size: clamp(28px, 4vw, 40px);
+        letter-spacing: 0.04em;
+      }
+
+      header p {
+        margin: 0 auto;
+        max-width: 780px;
+        line-height: 1.7;
+        color: rgba(226, 232, 240, 0.8);
+      }
+
+      main {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 12px 16px 64px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+      }
+
+      .toolbar {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+      }
+
+      .back-link {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .back-link::before {
+        content: "←";
+        font-size: 18px;
+      }
+
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+      }
+
+      .controls label {
+        font-size: 14px;
+        color: rgba(148, 163, 184, 0.9);
+      }
+
+      select,
+      button {
+        border: 1px solid rgba(59, 130, 246, 0.35);
+        background-color: rgba(30, 64, 175, 0.35);
+        color: #bfdbfe;
+        border-radius: 999px;
+        padding: 6px 16px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background 0.2s ease, border-color 0.2s ease;
+      }
+
+      select:hover,
+      button:hover,
+      select:focus-visible,
+      button:focus-visible {
+        border-color: rgba(96, 165, 250, 0.8);
+        background-color: rgba(37, 99, 235, 0.45);
+        outline: none;
+      }
+
+      button.secondary {
+        border-color: rgba(45, 212, 191, 0.4);
+        background-color: rgba(17, 94, 89, 0.35);
+        color: #a7f3d0;
+      }
+
+      button.danger {
+        border-color: rgba(248, 113, 113, 0.45);
+        background-color: rgba(153, 27, 27, 0.4);
+        color: #fecaca;
+      }
+
+      .content {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 320px;
+        gap: 18px;
+      }
+
+      @media (max-width: 1024px) {
+        .content {
+          grid-template-columns: 1fr;
+        }
+
+        .side-panel {
+          order: -1;
+        }
+      }
+
+      .diagram-area {
+        background: rgba(15, 23, 42, 0.7);
+        border-radius: 24px;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 26px 70px rgba(2, 6, 23, 0.65);
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      #diagramDiv {
+        width: 100%;
+        height: 640px;
+        border-radius: 18px;
+        background: radial-gradient(circle at center, rgba(30, 64, 175, 0.24), rgba(15, 23, 42, 0.95));
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+
+      .stats-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        font-size: 14px;
+        color: rgba(226, 232, 240, 0.78);
+      }
+
+      .side-panel {
+        background: rgba(15, 23, 42, 0.78);
+        border-radius: 24px;
+        border: 1px solid rgba(148, 163, 184, 0.24);
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+        box-shadow: 0 18px 50px rgba(2, 6, 23, 0.55);
+      }
+
+      .side-panel h2 {
+        margin: 0;
+        font-size: 18px;
+        color: #bae6fd;
+        letter-spacing: 0.02em;
+      }
+
+      .legend {
+        display: grid;
+        gap: 10px;
+        font-size: 13px;
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .legend-swatch {
+        width: 14px;
+        height: 14px;
+        border-radius: 4px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+      }
+
+      .detail-panel h3 {
+        margin: 0 0 10px;
+        font-size: 16px;
+        color: #f8fafc;
+      }
+
+      .detail-grid {
+        display: grid;
+        gap: 10px;
+        font-size: 13px;
+      }
+
+      .detail-grid div {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        color: rgba(226, 232, 240, 0.78);
+      }
+
+      .detail-grid dt {
+        margin: 0;
+        font-weight: 500;
+        color: rgba(148, 163, 184, 0.9);
+      }
+
+      .detail-grid dd {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>配电网运行监控示例</h1>
+      <p>
+        该示例以 110kV 石景山变电站为核心，搭建四条主馈线及多处联络开关。
+        可视化展示站-线-台区-用户的层级结构，同时提供负荷统计、馈线聚焦、停电演练与负荷均衡等交互能力，帮助快速体验配电自动化的日常监控流程。
+      </p>
+    </header>
+    <main>
+      <div class="toolbar">
+        <a class="back-link" href="../index.html">返回布局画廊</a>
+        <div class="controls">
+          <label for="feederSelect">聚焦馈线：</label>
+          <select id="feederSelect" aria-label="选择要聚焦的馈线">
+            <option value="all">全部馈线</option>
+            <option value="F1">Ⅰ# 馈线</option>
+            <option value="F2">Ⅱ# 馈线</option>
+            <option value="F3">Ⅲ# 馈线</option>
+            <option value="F4">Ⅳ# 馈线</option>
+          </select>
+          <button class="danger" id="simulateOutage">模拟故障转供</button>
+          <button class="secondary" id="balanceLoad">均衡负荷方案</button>
+          <button id="resetNetwork">恢复正常</button>
+        </div>
+      </div>
+      <section class="content">
+        <div class="diagram-area">
+          <div
+            id="diagramDiv"
+            role="presentation"
+            aria-label="配电网运行监控示例"
+          ></div>
+          <div class="stats-bar">
+            <span id="networkStats">运行状态统计</span>
+            <span id="loadStats">综合负荷统计</span>
+          </div>
+        </div>
+        <aside class="side-panel">
+          <h2>运行监控面板</h2>
+          <div class="legend" aria-label="符号图例">
+            <div class="legend-item">
+              <span class="legend-swatch" style="background:#14b8a6"></span>
+              <span>绿色：运行正常</span>
+            </div>
+            <div class="legend-item">
+              <span class="legend-swatch" style="background:#f59e0b"></span>
+              <span>橙色：负荷预警</span>
+            </div>
+            <div class="legend-item">
+              <span class="legend-swatch" style="background:#ef4444"></span>
+              <span>红色：停电或退出</span>
+            </div>
+            <div class="legend-item">
+              <span class="legend-swatch" style="background:linear-gradient(135deg,#38bdf8,#60a5fa)"></span>
+              <span>虚线：联络开关反送通道</span>
+            </div>
+          </div>
+          <div class="detail-panel" aria-live="polite">
+            <h3 id="detailTitle">选择任意设备查看详情</h3>
+            <dl class="detail-grid">
+              <div>
+                <dt>设备类型</dt>
+                <dd id="detailType">-</dd>
+              </div>
+              <div>
+                <dt>运行状态</dt>
+                <dd id="detailStatus">-</dd>
+              </div>
+              <div>
+                <dt>当前负荷</dt>
+                <dd id="detailLoad">-</dd>
+              </div>
+              <div>
+                <dt>所属馈线</dt>
+                <dd id="detailFeeder">-</dd>
+              </div>
+              <div id="detailStateRow">
+                <dt>开关状态</dt>
+                <dd id="detailState">-</dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
+      </section>
+    </main>
+    <script>
+      window.addEventListener("DOMContentLoaded", () => {
+        const $ = go.GraphObject.make;
+
+        const statusPalette = {
+          normal: { fill: "rgba(20, 184, 166, 0.85)", stroke: "#14b8a6" },
+          alert: { fill: "rgba(245, 158, 11, 0.85)", stroke: "#f59e0b" },
+          outage: { fill: "rgba(239, 68, 68, 0.9)", stroke: "#ef4444" },
+        };
+
+        const statusLabelMap = {
+          normal: "运行正常",
+          alert: "负荷预警",
+          outage: "停电退出",
+        };
+
+        const typeLabelMap = {
+          substation: "变电站",
+          feeder: "馈线",
+          transformer: "配电变压器",
+          load: "重要用户",
+          switch: "联络开关",
+        };
+
+        const feederNameMap = {
+          F1: "Ⅰ# 馈线",
+          F2: "Ⅱ# 馈线",
+          F3: "Ⅲ# 馈线",
+          F4: "Ⅳ# 馈线",
+        };
+
+        function statusFill(status) {
+          return (statusPalette[status] || statusPalette.normal).fill;
+        }
+
+        function statusStroke(status) {
+          return (statusPalette[status] || statusPalette.normal).stroke;
+        }
+
+        function statusLabel(status) {
+          return statusLabelMap[status] || statusLabelMap.normal;
+        }
+
+        function formatLoad(data) {
+          if (typeof data.load !== "number") return "";
+          const unit = data.unit || "MW";
+          return `负荷 ${data.load.toFixed(1)} ${unit}`;
+        }
+
+        function makeTemplate(options) {
+          return $(
+            go.Node,
+            "Spot",
+            {
+              locationSpot: go.Spot.Center,
+              selectionAdorned: false,
+              cursor: "pointer",
+              toolTip: $(
+                go.Adornment,
+                "Auto",
+                $(go.Shape, "RoundedRectangle", {
+                  fill: "rgba(15, 23, 42, 0.92)",
+                  stroke: "rgba(148, 163, 184, 0.45)",
+                  parameter1: 8,
+                }),
+                $(
+                  go.Panel,
+                  "Table",
+                  { padding: 8, defaultAlignment: go.Spot.Left },
+                  $(
+                    go.TextBlock,
+                    {
+                      row: 0,
+                      columnSpan: 2,
+                      font: "600 13px 'Segoe UI'",
+                      stroke: "#f8fafc",
+                      margin: new go.Margin(0, 0, 6, 0),
+                    },
+                    new go.Binding("text", "text")
+                  ),
+                  $(go.TextBlock, "类型", { row: 1, column: 0, stroke: "#94a3b8" }),
+                  $(
+                    go.TextBlock,
+                    { row: 1, column: 1, stroke: "#e2e8f0" },
+                    new go.Binding("text", "category", (c) => typeLabelMap[c] || "设备")
+                  ),
+                  $(go.TextBlock, "状态", { row: 2, column: 0, stroke: "#94a3b8" }),
+                  $(
+                    go.TextBlock,
+                    { row: 2, column: 1, stroke: "#e2e8f0" },
+                    new go.Binding("text", "status", statusLabel)
+                  ),
+                  $(go.TextBlock, "负荷", { row: 3, column: 0, stroke: "#94a3b8" }),
+                  $(
+                    go.TextBlock,
+                    { row: 3, column: 1, stroke: "#e2e8f0" },
+                    new go.Binding("text", "", formatLoad)
+                  )
+                )
+              ),
+            },
+            $(
+              go.Panel,
+              "Auto",
+              $(
+                go.Shape,
+                options.figure || "RoundedRectangle",
+                {
+                  desiredSize: new go.Size(options.width, options.height),
+                  fill: statusFill("normal"),
+                  stroke: statusStroke("normal"),
+                  strokeWidth: 1.6,
+                  parameter1: options.corner || 0,
+                },
+                new go.Binding("fill", "status", statusFill),
+                new go.Binding("stroke", "status", statusStroke)
+              ),
+              $(
+                go.Panel,
+                "Vertical",
+                {
+                  margin: new go.Margin(10, 12, 10, 12),
+                  alignment: go.Spot.Center,
+                  defaultAlignment: go.Spot.Center,
+                },
+                $(
+                  go.TextBlock,
+                  {
+                    font: "600 14px 'Segoe UI'",
+                    stroke: "#f8fafc",
+                    textAlign: "center",
+                    wrap: go.TextBlock.WrapFit,
+                    width: options.width - 24,
+                    margin: new go.Margin(0, 0, 6, 0),
+                  },
+                  new go.Binding("text", "text")
+                ),
+                $(
+                  go.TextBlock,
+                  {
+                    font: "12px 'Segoe UI'",
+                    stroke: "rgba(248, 250, 252, 0.8)",
+                    textAlign: "center",
+                    wrap: go.TextBlock.WrapFit,
+                    width: options.width - 24,
+                    margin: new go.Margin(0, 0, 4, 0),
+                  },
+                  new go.Binding("text", "status", statusLabel)
+                ),
+                $(
+                  go.TextBlock,
+                  {
+                    font: "11px 'Segoe UI'",
+                    stroke: "#bae6fd",
+                    textAlign: "center",
+                    wrap: go.TextBlock.WrapFit,
+                    width: options.width - 24,
+                    margin: new go.Margin(0, 0, 2, 0),
+                  },
+                  new go.Binding("text", "", formatLoad)
+                )
+              )
+            ),
+            $(
+              go.Shape,
+              options.figure || "RoundedRectangle",
+              {
+                desiredSize: new go.Size(options.width + 8, options.height + 8),
+                fill: null,
+                stroke: "#facc15",
+                strokeWidth: 3,
+                opacity: 0,
+                parameter1: options.corner || 0,
+              },
+              new go.Binding("opacity", "isHighlighted", (h) => (h ? 1 : 0)).ofObject()
+            )
+          );
+        }
+
+        const diagram = $(go.Diagram, "diagramDiv", {
+          layout: $(go.LayeredDigraphLayout, {
+            direction: 90,
+            layerSpacing: 120,
+            columnSpacing: 40,
+            setsPortSpots: false,
+          }),
+          initialAutoScale: go.Diagram.Uniform,
+          allowZoom: true,
+          "undoManager.isEnabled": false,
+        });
+
+        diagram.nodeTemplateMap.add(
+          "substation",
+          makeTemplate({ figure: "RoundedRectangle", width: 170, height: 96, corner: 14 })
+        );
+        diagram.nodeTemplateMap.add(
+          "feeder",
+          makeTemplate({ figure: "RoundedRectangle", width: 150, height: 90, corner: 12 })
+        );
+        diagram.nodeTemplateMap.add(
+          "transformer",
+          makeTemplate({ figure: "RoundedRectangle", width: 140, height: 84, corner: 12 })
+        );
+        diagram.nodeTemplateMap.add(
+          "load",
+          makeTemplate({ figure: "Circle", width: 82, height: 82 })
+        );
+        diagram.nodeTemplateMap.add(
+          "switch",
+          makeTemplate({ figure: "Diamond", width: 90, height: 90 })
+        );
+
+        diagram.linkTemplate = $(
+          go.Link,
+          {
+            routing: go.Link.Orthogonal,
+            corner: 8,
+            toShortLength: 6,
+            adjusting: go.Link.End,
+          },
+          $(
+            go.Shape,
+            {
+              stroke: "rgba(148, 163, 184, 0.55)",
+              strokeWidth: 2,
+            },
+            new go.Binding("stroke", "isHighlighted", (h) => (h ? "#fde68a" : "rgba(148, 163, 184, 0.55)")).ofObject(),
+            new go.Binding("strokeWidth", "isHighlighted", (h) => (h ? 3.4 : 2)).ofObject()
+          ),
+          $(
+            go.Shape,
+            {
+              toArrow: "RoundedTriangle",
+              fill: "rgba(148, 163, 184, 0.9)",
+              stroke: null,
+            },
+            new go.Binding("fill", "isHighlighted", (h) => (h ? "#fde68a" : "rgba(148, 163, 184, 0.9)")).ofObject()
+          )
+        );
+
+        diagram.linkTemplateMap.add(
+          "tie",
+          $(
+            go.Link,
+            {
+              routing: go.Link.Orthogonal,
+              corner: 10,
+              adjusting: go.Link.End,
+            },
+            $(
+              go.Shape,
+              {
+                stroke: "rgba(56, 189, 248, 0.85)",
+                strokeWidth: 2,
+                strokeDashArray: [6, 4],
+              },
+              new go.Binding("stroke", "isHighlighted", (h) => (h ? "#facc15" : "rgba(56, 189, 248, 0.85)")).ofObject(),
+              new go.Binding("strokeWidth", "isHighlighted", (h) => (h ? 3.4 : 2)).ofObject()
+            ),
+            $(
+              go.Shape,
+              {
+                toArrow: "Standard",
+                fill: "rgba(56, 189, 248, 0.85)",
+                stroke: null,
+              },
+              new go.Binding("fill", "isHighlighted", (h) => (h ? "#facc15" : "rgba(56, 189, 248, 0.85)")).ofObject()
+            )
+          )
+        );
+
+        const nodeDataArray = [
+          {
+            key: "S1",
+            category: "substation",
+            text: "石景山 110kV 变电站",
+            status: "normal",
+            baseStatus: "normal",
+            load: 24.6,
+            baseLoad: 24.6,
+            capacity: 60,
+            unit: "MW",
+          },
+          {
+            key: "F1",
+            category: "feeder",
+            text: "Ⅰ# 馈线",
+            status: "normal",
+            baseStatus: "normal",
+            load: 6.5,
+            baseLoad: 6.5,
+            capacity: 12,
+            unit: "MW",
+            feeder: "F1",
+          },
+          {
+            key: "F2",
+            category: "feeder",
+            text: "Ⅱ# 馈线",
+            status: "normal",
+            baseStatus: "normal",
+            load: 6.0,
+            baseLoad: 6.0,
+            capacity: 12,
+            unit: "MW",
+            feeder: "F2",
+          },
+          {
+            key: "F3",
+            category: "feeder",
+            text: "Ⅲ# 馈线",
+            status: "normal",
+            baseStatus: "normal",
+            load: 5.8,
+            baseLoad: 5.8,
+            capacity: 12,
+            unit: "MW",
+            feeder: "F3",
+          },
+          {
+            key: "F4",
+            category: "feeder",
+            text: "Ⅳ# 馈线",
+            status: "normal",
+            baseStatus: "normal",
+            load: 5.7,
+            baseLoad: 5.7,
+            capacity: 12,
+            unit: "MW",
+            feeder: "F4",
+          },
+          {
+            key: "SW12",
+            category: "switch",
+            text: "联络开关 A",
+            status: "normal",
+            baseStatus: "normal",
+            feeder: "Tie",
+            connectedFeeders: ["F1", "F2"],
+            state: "open",
+            baseState: "open",
+          },
+          {
+            key: "SW23",
+            category: "switch",
+            text: "联络开关 B",
+            status: "normal",
+            baseStatus: "normal",
+            feeder: "Tie",
+            connectedFeeders: ["F2", "F3"],
+            state: "open",
+            baseState: "open",
+          },
+          {
+            key: "SW24",
+            category: "switch",
+            text: "联络开关 C",
+            status: "normal",
+            baseStatus: "normal",
+            feeder: "Tie",
+            connectedFeeders: ["F2", "F4"],
+            state: "open",
+            baseState: "open",
+          },
+          {
+            key: "SW14",
+            category: "switch",
+            text: "联络开关 D",
+            status: "normal",
+            baseStatus: "normal",
+            feeder: "Tie",
+            connectedFeeders: ["F1", "F4"],
+            state: "open",
+            baseState: "open",
+          },
+          {
+            key: "T11",
+            category: "transformer",
+            text: "城南#1 配电室",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.3,
+            baseLoad: 2.3,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "T12",
+            category: "transformer",
+            text: "城南#2 配电室",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.1,
+            baseLoad: 2.1,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "T13",
+            category: "transformer",
+            text: "万达商业区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.1,
+            baseLoad: 2.1,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "T21",
+            category: "transformer",
+            text: "永丰工业区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.0,
+            baseLoad: 2.0,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "T22",
+            category: "transformer",
+            text: "海淀科技园",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.2,
+            baseLoad: 2.2,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "T23",
+            category: "transformer",
+            text: "清河生活区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.8,
+            baseLoad: 1.8,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "T31",
+            category: "transformer",
+            text: "学院路站点",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.0,
+            baseLoad: 2.0,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "T32",
+            category: "transformer",
+            text: "中关村社区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.9,
+            baseLoad: 1.9,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "T33",
+            category: "transformer",
+            text: "沙河高教园",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.9,
+            baseLoad: 1.9,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "T41",
+            category: "transformer",
+            text: "南苑#1 配电室",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.6,
+            baseLoad: 2.6,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "T42",
+            category: "transformer",
+            text: "南苑#2 配电室",
+            status: "normal",
+            baseStatus: "normal",
+            load: 2.1,
+            baseLoad: 2.1,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "T43",
+            category: "transformer",
+            text: "空港保障区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.0,
+            baseLoad: 1.0,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "L111",
+            category: "load",
+            text: "市政应急中心",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.1,
+            baseLoad: 1.1,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "L112",
+            category: "load",
+            text: "地铁运控室",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.0,
+            baseLoad: 1.0,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "L121",
+            category: "load",
+            text: "科技园宿舍区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.0,
+            baseLoad: 1.0,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "L122",
+            category: "load",
+            text: "创客孵化中心",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "L131",
+            category: "load",
+            text: "万达写字楼",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.1,
+            baseLoad: 1.1,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "L132",
+            category: "load",
+            text: "商业综合体",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.0,
+            baseLoad: 1.0,
+            feeder: "F1",
+            unit: "MW",
+          },
+          {
+            key: "L211",
+            category: "load",
+            text: "永丰企业 A",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "L212",
+            category: "load",
+            text: "永丰企业 B",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "L221",
+            category: "load",
+            text: "科技园研发楼",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.1,
+            baseLoad: 1.1,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "L222",
+            category: "load",
+            text: "产业加速器",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.0,
+            baseLoad: 1.0,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "L231",
+            category: "load",
+            text: "清河居民 A",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "L232",
+            category: "load",
+            text: "清河居民 B",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.8,
+            baseLoad: 0.8,
+            feeder: "F2",
+            unit: "MW",
+          },
+          {
+            key: "L311",
+            category: "load",
+            text: "高校教学楼",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "L312",
+            category: "load",
+            text: "高校实验室",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.8,
+            baseLoad: 0.8,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "L321",
+            category: "load",
+            text: "居民小区 A",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "L322",
+            category: "load",
+            text: "居民小区 B",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.8,
+            baseLoad: 0.8,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "L331",
+            category: "load",
+            text: "沙河学生宿舍",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "L332",
+            category: "load",
+            text: "沙河实验楼",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.9,
+            baseLoad: 0.9,
+            feeder: "F3",
+            unit: "MW",
+          },
+          {
+            key: "L411",
+            category: "load",
+            text: "空港调度中心",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.3,
+            baseLoad: 1.3,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "L412",
+            category: "load",
+            text: "空港物流园",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.2,
+            baseLoad: 1.2,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "L421",
+            category: "load",
+            text: "南苑商业区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.1,
+            baseLoad: 1.1,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "L422",
+            category: "load",
+            text: "南苑居住区",
+            status: "normal",
+            baseStatus: "normal",
+            load: 1.0,
+            baseLoad: 1.0,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "L431",
+            category: "load",
+            text: "空港保障宿舍",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.5,
+            baseLoad: 0.5,
+            feeder: "F4",
+            unit: "MW",
+          },
+          {
+            key: "L432",
+            category: "load",
+            text: "空港后勤中心",
+            status: "normal",
+            baseStatus: "normal",
+            load: 0.4,
+            baseLoad: 0.4,
+            feeder: "F4",
+            unit: "MW",
+          },
+        ];
+        const linkDataArray = [
+          { from: "S1", to: "F1" },
+          { from: "S1", to: "F2" },
+          { from: "S1", to: "F3" },
+          { from: "S1", to: "F4" },
+          { from: "F1", to: "SW12", category: "tie", connectedFeeders: ["F1", "F2"] },
+          { from: "SW12", to: "F2", category: "tie", connectedFeeders: ["F1", "F2"] },
+          { from: "F3", to: "SW23", category: "tie", connectedFeeders: ["F2", "F3"] },
+          { from: "SW23", to: "F2", category: "tie", connectedFeeders: ["F2", "F3"] },
+          { from: "F2", to: "SW24", category: "tie", connectedFeeders: ["F2", "F4"] },
+          { from: "SW24", to: "F4", category: "tie", connectedFeeders: ["F2", "F4"] },
+          { from: "F1", to: "SW14", category: "tie", connectedFeeders: ["F1", "F4"] },
+          { from: "SW14", to: "F4", category: "tie", connectedFeeders: ["F1", "F4"] },
+          { from: "F1", to: "T11" },
+          { from: "F1", to: "T12" },
+          { from: "F1", to: "T13" },
+          { from: "F2", to: "T21" },
+          { from: "F2", to: "T22" },
+          { from: "F2", to: "T23" },
+          { from: "F3", to: "T31" },
+          { from: "F3", to: "T32" },
+          { from: "F3", to: "T33" },
+          { from: "F4", to: "T41" },
+          { from: "F4", to: "T42" },
+          { from: "F4", to: "T43" },
+          { from: "T11", to: "L111" },
+          { from: "T11", to: "L112" },
+          { from: "T12", to: "L121" },
+          { from: "T12", to: "L122" },
+          { from: "T13", to: "L131" },
+          { from: "T13", to: "L132" },
+          { from: "T21", to: "L211" },
+          { from: "T21", to: "L212" },
+          { from: "T22", to: "L221" },
+          { from: "T22", to: "L222" },
+          { from: "T23", to: "L231" },
+          { from: "T23", to: "L232" },
+          { from: "T31", to: "L311" },
+          { from: "T31", to: "L312" },
+          { from: "T32", to: "L321" },
+          { from: "T32", to: "L322" },
+          { from: "T33", to: "L331" },
+          { from: "T33", to: "L332" },
+          { from: "T41", to: "L411" },
+          { from: "T41", to: "L412" },
+          { from: "T42", to: "L421" },
+          { from: "T42", to: "L422" },
+          { from: "T43", to: "L431" },
+          { from: "T43", to: "L432" },
+        ];
+        diagram.model = new go.GraphLinksModel(nodeDataArray, linkDataArray);
+
+        const feederSelect = document.getElementById("feederSelect");
+        const networkStats = document.getElementById("networkStats");
+        const loadStats = document.getElementById("loadStats");
+        const detailTitle = document.getElementById("detailTitle");
+        const detailType = document.getElementById("detailType");
+        const detailStatus = document.getElementById("detailStatus");
+        const detailLoad = document.getElementById("detailLoad");
+        const detailFeeder = document.getElementById("detailFeeder");
+        const detailState = document.getElementById("detailState");
+        const detailStateRow = document.getElementById("detailStateRow");
+
+        function setStatus(key, status) {
+          const data = diagram.model.findNodeDataForKey(key);
+          if (data) diagram.model.setDataProperty(data, "status", status);
+        }
+
+        function setLoad(key, load) {
+          const data = diagram.model.findNodeDataForKey(key);
+          if (data && typeof load === "number") {
+            diagram.model.setDataProperty(data, "load", load);
+          }
+        }
+
+        function setState(key, state) {
+          const data = diagram.model.findNodeDataForKey(key);
+          if (data) diagram.model.setDataProperty(data, "state", state);
+        }
+
+        function resetHighlights() {
+          diagram.nodes.each((node) => {
+            node.isHighlighted = false;
+          });
+          diagram.links.each((link) => {
+            link.isHighlighted = false;
+          });
+        }
+
+        function highlightFeeder(feederKey) {
+          diagram.startTransaction("highlight-feeder");
+          resetHighlights();
+          if (feederKey !== "all") {
+            diagram.nodes.each((node) => {
+              const feeders = node.data.connectedFeeders;
+              if (node.data.feeder === feederKey) {
+                node.isHighlighted = true;
+              } else if (Array.isArray(feeders) && feeders.includes(feederKey)) {
+                node.isHighlighted = true;
+              }
+              if (node.data.key === "S1") {
+                node.isHighlighted = true;
+              }
+            });
+            diagram.links.each((link) => {
+              const fromFeeder = link.fromNode && link.fromNode.data.feeder;
+              const toFeeder = link.toNode && link.toNode.data.feeder;
+              if (
+                (fromFeeder === feederKey && toFeeder === feederKey) ||
+                (link.fromNode && link.fromNode.data.key === "S1" && toFeeder === feederKey)
+              ) {
+                link.isHighlighted = true;
+              } else if (Array.isArray(link.data.connectedFeeders) && link.data.connectedFeeders.includes(feederKey)) {
+                link.isHighlighted = true;
+              }
+            });
+          }
+          diagram.commitTransaction("highlight-feeder");
+        }
+
+        function updateStats() {
+          let normal = 0;
+          let alert = 0;
+          let outage = 0;
+          let totalLoad = 0;
+          let offlineLoads = 0;
+
+          diagram.nodes.each((node) => {
+            const { status, load, category } = node.data;
+            if (status === "alert") alert += 1;
+            else if (status === "outage") outage += 1;
+            else normal += 1;
+
+            if (typeof load === "number") {
+              totalLoad += load;
+            }
+            if (category === "load" && status === "outage") {
+              offlineLoads += 1;
+            }
+          });
+
+          networkStats.textContent = `正常 ${normal} · 预警 ${alert} · 停电 ${outage}`;
+          loadStats.textContent = `综合负荷 ${totalLoad.toFixed(1)} MW · 离线用户 ${offlineLoads}`;
+        }
+
+        function updateDetailPanel(part) {
+          if (part && part instanceof go.Node) {
+            const data = part.data;
+            detailTitle.textContent = data.text;
+            detailType.textContent = typeLabelMap[data.category] || "设备";
+            detailStatus.textContent = statusLabel(data.status);
+            if (typeof data.load === "number") {
+              detailLoad.textContent = `${data.load.toFixed(1)} ${data.unit || "MW"}`;
+            } else {
+              detailLoad.textContent = "-";
+            }
+            if (data.feeder && feederNameMap[data.feeder]) {
+              detailFeeder.textContent = feederNameMap[data.feeder];
+            } else if (Array.isArray(data.connectedFeeders) && data.connectedFeeders.length) {
+              detailFeeder.textContent = data.connectedFeeders.map((f) => feederNameMap[f]).join(" / ");
+            } else {
+              detailFeeder.textContent = "站内";
+            }
+            if (data.state) {
+              detailStateRow.style.display = "flex";
+              detailState.textContent = data.state === "closed" ? "闭合" : "分断";
+            } else {
+              detailStateRow.style.display = "none";
+              detailState.textContent = "-";
+            }
+          } else {
+            detailTitle.textContent = "选择任意设备查看详情";
+            detailType.textContent = "-";
+            detailStatus.textContent = "-";
+            detailLoad.textContent = "-";
+            detailFeeder.textContent = "-";
+            detailStateRow.style.display = "none";
+            detailState.textContent = "-";
+          }
+        }
+
+        function resetNetwork(shouldUpdateDetail = true) {
+          diagram.startTransaction("reset-network");
+          diagram.nodes.each((node) => {
+            const data = node.data;
+            const baseStatus = data.baseStatus || "normal";
+            if (data.status !== baseStatus) {
+              diagram.model.setDataProperty(data, "status", baseStatus);
+            }
+            if (typeof data.baseLoad === "number" && data.load !== data.baseLoad) {
+              diagram.model.setDataProperty(data, "load", data.baseLoad);
+            }
+            if (data.baseState && data.state !== data.baseState) {
+              diagram.model.setDataProperty(data, "state", data.baseState);
+            }
+          });
+          resetHighlights();
+          diagram.commitTransaction("reset-network");
+          if (shouldUpdateDetail) {
+            diagram.clearSelection();
+            updateDetailPanel(null);
+          }
+          feederSelect.value = "all";
+          highlightFeeder("all");
+          updateStats();
+        }
+
+        function simulateOutage() {
+          resetNetwork(false);
+          diagram.startTransaction("simulate-outage");
+          setStatus("F2", "alert");
+          setStatus("T22", "outage");
+          setStatus("T23", "outage");
+          setStatus("L221", "outage");
+          setStatus("L222", "outage");
+          setStatus("L231", "outage");
+          setStatus("L232", "outage");
+          setLoad("F2", 3.4);
+          setLoad("T22", 0);
+          setLoad("T23", 0);
+          setLoad("L221", 0);
+          setLoad("L222", 0);
+          setLoad("L231", 0);
+          setLoad("L232", 0);
+          setStatus("SW23", "alert");
+          setState("SW23", "closed");
+          setStatus("SW24", "alert");
+          setState("SW24", "closed");
+          setStatus("F3", "alert");
+          setStatus("F4", "alert");
+          setLoad("F3", 7.0);
+          setLoad("T31", 2.6);
+          setLoad("T33", 2.4);
+          setStatus("L312", "alert");
+          setLoad("L312", 1.1);
+          setStatus("L331", "alert");
+          setLoad("L331", 1.2);
+          setLoad("F4", 7.0);
+          setLoad("T41", 3.1);
+          setLoad("T42", 2.5);
+          setStatus("L421", "alert");
+          setLoad("L421", 1.4);
+          diagram.links.each((link) => {
+            if (
+              (link.data.from === "F3" && link.data.to === "SW23") ||
+              (link.data.from === "SW23" && link.data.to === "F2") ||
+              (link.data.from === "F2" && link.data.to === "SW24") ||
+              (link.data.from === "SW24" && link.data.to === "F4")
+            ) {
+              link.isHighlighted = true;
+            }
+          });
+          diagram.commitTransaction("simulate-outage");
+          diagram.clearSelection();
+          updateDetailPanel(null);
+          feederSelect.value = "all";
+          highlightFeeder("all");
+          updateStats();
+        }
+
+        function balanceLoad() {
+          resetNetwork(false);
+          diagram.startTransaction("balance-load");
+          setLoad("S1", 24.0);
+          setLoad("F1", 6.0);
+          setLoad("F2", 6.0);
+          setLoad("F3", 6.0);
+          setLoad("F4", 6.0);
+          setLoad("T11", 2.0);
+          setLoad("T12", 2.0);
+          setLoad("T13", 2.0);
+          setLoad("T21", 2.0);
+          setLoad("T22", 2.0);
+          setLoad("T23", 2.0);
+          setLoad("T31", 2.0);
+          setLoad("T32", 2.0);
+          setLoad("T33", 2.0);
+          setLoad("T41", 2.2);
+          setLoad("T42", 2.0);
+          setLoad("T43", 1.8);
+          setLoad("L312", 1.0);
+          setLoad("L331", 1.0);
+          setLoad("L421", 1.2);
+          setStatus("F1", "normal");
+          setStatus("F2", "normal");
+          setStatus("F3", "normal");
+          setStatus("F4", "normal");
+          diagram.commitTransaction("balance-load");
+          diagram.clearSelection();
+          updateDetailPanel(null);
+          feederSelect.value = "all";
+          highlightFeeder("all");
+          updateStats();
+        }
+
+        diagram.addDiagramListener("ChangedSelection", () => {
+          const part = diagram.selection.first();
+          updateDetailPanel(part instanceof go.Part ? part : null);
+        });
+
+        feederSelect.addEventListener("change", () => {
+          highlightFeeder(feederSelect.value);
+        });
+
+        document.getElementById("simulateOutage").addEventListener("click", simulateOutage);
+        document.getElementById("balanceLoad").addEventListener("click", balanceLoad);
+        document.getElementById("resetNetwork").addEventListener("click", () => resetNetwork(true));
+
+        resetNetwork(true);
+      });
+    </script>
+  </body>
+</html>

--- a/layouts/double-tree.html
+++ b/layouts/double-tree.html
@@ -184,7 +184,7 @@
         buildSide(rightPlan, "right");
 
         const diagram = $(go.Diagram, "diagramDiv", {
-          layout: new go.DoubleTreeLayout({
+          layout: new DoubleTreeLayout({
             directionFunction: (node) => node.data && node.data.dir !== "left",
             bottomRightOptions: { nodeSpacing: 18, layerSpacing: 36 },
             topLeftOptions: { nodeSpacing: 18, layerSpacing: 36 },

--- a/layouts/packed.html
+++ b/layouts/packed.html
@@ -173,12 +173,12 @@
 
         const diagram = $(go.Diagram, "diagramDiv", {
           layout: new go.PackedLayout({
-            packShape: go.PackShape.Elliptical,
-            packMode: go.PackMode.Fit,
+            packShape: PackShape.Elliptical,
+            packMode: PackMode.Fit,
             aspectRatio: 1,
             spacing: 16,
-            sortMode: go.SortMode.Area,
-            sortOrder: go.SortOrder.Descending,
+            sortMode: SortMode.Area,
+            sortOrder: SortOrder.Descending,
           }),
           initialAutoScale: go.Diagram.Uniform,
           allowZoom: true,


### PR DESCRIPTION
## Summary
- add a homepage card that links到配电网行业示例，突出可交互监控与负荷演练
- build a distribution-network example page with GoJS that includes feeder highlighting, outage simulation, and load balancing controls
- surface live stats and a detail panel so选中设备时能查看运行状态、负荷与开关信息
- expand the network dataset with a fourth feeder, additional tie switches, and more transformers/loads while fixing the template gap error

## Testing
- not run (HTML change only)

------
https://chatgpt.com/codex/tasks/task_b_68d13dd4c6288327871f29c353b6f844